### PR TITLE
Removed the soft currency converters in Amount.

### DIFF
--- a/common/currency.h
+++ b/common/currency.h
@@ -140,11 +140,6 @@ struct Amount {
         return result;
     }
 
-    int64_t toMicro() const    { return value; }
-    double  toUnit() const     { return value / 1000000.0; }
-    double  toCPM() const      { return value * 0.001; }
-    int64_t toMicroCPM() const { return value * 1000; }
-
     static std::string getCurrencyStr(CurrencyCode currencyCode);
     std::string getCurrencyStr() const;
     static CurrencyCode parseCurrency(const std::string & currency);
@@ -179,7 +174,10 @@ struct MicroUSD : public Amount {
             ExcAssertEqual(currencyCode, CurrencyCode::CC_USD);
     }
 
-    operator int64_t () const { return toMicro(); }
+    operator int64_t () const
+    {
+        return value;
+    }
 };
 
 struct USD : public Amount {
@@ -195,7 +193,10 @@ struct USD : public Amount {
             ExcAssertEqual(currencyCode, CurrencyCode::CC_USD);
     }
     
-    operator double () const { return toUnit(); }
+    operator double () const
+    {
+        return value / 1000000.0;
+    }
 };
 
 struct USD_CPM : public Amount {
@@ -211,7 +212,7 @@ struct USD_CPM : public Amount {
             ExcAssertEqual(currencyCode, CurrencyCode::CC_USD);
     }
 
-    operator double () const { return toCPM(); }
+    operator double () const { return value * 0.001; }
 };
 
 struct MicroUSD_CPM : public Amount {
@@ -227,7 +228,10 @@ struct MicroUSD_CPM : public Amount {
             ExcAssertEqual(currencyCode, CurrencyCode::CC_USD);
     }
 
-    operator int64_t () const { return toMicroCPM(); }
+    operator int64_t () const
+    {
+        return value * 1000;
+    }
 };
 
 /*****************************************************************************/

--- a/js/currency_js.cc
+++ b/js/currency_js.cc
@@ -91,11 +91,6 @@ struct AmountJS :
         registerMemberFn(&Amount::operator>=, "ge");
         registerMemberFn(&Amount::operator==, "equals");
 
-        registerMemberFn(&Amount::toMicro, "toMicro");
-        registerMemberFn(&Amount::toUnit, "toUnit");
-        registerMemberFn(&Amount::toCPM, "toCPM");
-        registerMemberFn(&Amount::toMicroCPM, "toMicroCPM");
-
         NODE_SET_PROTOTYPE_METHOD(t, "currencyCode", getCurrencyCode);
     }
 

--- a/plugins/bidding_agent/bidding_agent.cc
+++ b/plugins/bidding_agent/bidding_agent.cc
@@ -552,7 +552,9 @@ doBid(Id id, const Bids & bids, const Json::Value & jsonMeta)
             if (bid.isNullBid()) recordHit("filtered.total");
             else {
                 recordHit("bids");
-                recordLevel(bid.price.toMicro(), "bidPrice");
+                recordLevel(
+                        bid.price.value,
+                        "bidPrice." + bid.price.getCurrencyStr());
             }
         }
 


### PR DESCRIPTION
The problem with these is that they would not work properly on
different currencies which operate on different scale. This also means
that when we log amounts to carbon, we have to append the currency to
the logging key in order to avoid mixing the amounts of two different
currencies.

Merge should be postponed until we can stabilize rtbkit a bit more.
