### PR TITLE
SegmentsBySourceJS: fixed handling of numerical indexes passed as string

### DIFF
--- a/js/bid_request_js.cc
+++ b/js/bid_request_js.cc
@@ -351,9 +351,65 @@ struct SegmentsBySourceJS
         Persistent<FunctionTemplate> t = Register(New);
 
         t->InstanceTemplate()
+            ->SetIndexedPropertyHandler(getIndexed, setIndexed, queryIndexed,
+                                        deleteIndexed, listIndexed);
+        t->InstanceTemplate()
             ->SetNamedPropertyHandler(getNamed, setNamed, queryNamed,
                                       deleteNamed, listNamed);
+    }
 
+    static v8::Handle<v8::Value>
+    getIndexed(uint32_t index, const v8::AccessorInfo & info)
+    {
+        try {
+            SegmentsBySource * segs = getShared(info.This());
+
+            string strIdx = to_string(index);
+            return (segs->count(strIdx) > 0
+                    ? JS::toJS(segs->at(strIdx))
+                    : NULL_HANDLE);
+        } HANDLE_JS_EXCEPTIONS;
+    }
+
+    static v8::Handle<v8::Value>
+    setIndexed(uint32_t index,
+               v8::Local<v8::Value> value,
+               const v8::AccessorInfo & info)
+    {
+        try {
+            throw ML::Exception("can't modify segments argument");
+        } HANDLE_JS_EXCEPTIONS;
+    }
+
+    static v8::Handle<v8::Integer>
+    queryIndexed(uint32_t index,
+                 const v8::AccessorInfo & info)
+    {
+        SegmentsBySource * segs = getShared(info.This());
+
+        string strIdx = to_string(index);
+        return (segs->count(strIdx) > 0
+                ? v8::Integer::New(ReadOnly | DontDelete)
+                : NULL_HANDLE);
+    }
+
+    static v8::Handle<v8::Array>
+    listIndexed(const v8::AccessorInfo & info)
+    {
+        v8::HandleScope scope;
+        SegmentsBySource * segs = getShared(info.This());
+
+        int sz = segs->size();
+        v8::Handle<v8::Array> result(v8::Array::New(sz));
+
+        return scope.Close(result);
+    }
+
+    static v8::Handle<v8::Boolean>
+    deleteIndexed(uint32_t index,
+                  const v8::AccessorInfo & info)
+    {
+        return NULL_HANDLE;
     }
 
     static v8::Handle<v8::Value>

--- a/testing/bid_request_js_segments_test.js
+++ b/testing/bid_request_js_segments_test.js
@@ -1,0 +1,118 @@
+/* rtb_bid_request_segments_test.js
+ * Wolfgang Sourdeau, April 2013
+ * Copyright (c) 2013 Datacratic.  All rights reserved.
+ *
+ * Tests for the bid request.
+ */
+
+var vows   = require('vows');
+var assert = require('assert');
+var brm    = require('bid_request');
+
+var requestWithSegments
+    = {"!!CV": "RTBKIT-JSON-1.0",
+       "bidCurrency": ["USD"],
+       "device": {"carrier": "Carrier Something",
+                  "geo": {"city": "Chicago",
+                          "country": "US",
+                          "metro": "312",
+                          "region": "IL"},
+                  "ip": "666.21.123.234",
+                  "language": "en-US, en;q=0.8",
+                  "make": "Motorola",
+                  "model": "DROID RAZR",
+                  "os": "Android",
+                  "osv": "2.3.5",
+                  "ua": "Mozilla/5.0 (Linux; Android 4.1.2; DROID RAZR Build/9.8.2O-72_VZW-16) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31"},
+       "exchange": "zeExchange",
+       "id": "148ce45e066a4ef2e6e4b927dc881ad6f209cf4b",
+       "imp": [{"banner": {"h": 250,
+                           "pos": 3,
+                           "w": 300},
+                "formats": ["300x250"],
+                "id": "1"}],
+       "ipAddress": "666.21.123.234",
+       "language": "en-US,en;q=0.8",
+       "location": {"cityName": "Chicago",
+                    "countryCode": "US",
+                    "regionCode": "IL"},
+       "provider": "zeProvider",
+       "segments": {"100": [1, 43, 125],
+                    "segid": ["Atext", "text1"],
+                    "tags": ["cid: 54455"]},
+       "site": {"domain": "http://domain.com",
+                "id": "1-18039",
+                "page": "http://domain.com/",
+                "publisher": {"id": "9725"}},
+       "spots": [{"banner": {"h": 250,
+                             "pos": 3,
+                             "w": 300},
+                  "formats": ["300x250"],
+                  "id": "1"}],
+       "timestamp": 1366768734.7632546,
+       "url": "http:  //domain.com/",
+       "user": {"buyeruid": "somid",
+                "data": [{"id": "100",
+                          "segment": [{"id": "1"},
+                                      {"id": "43"},
+                                      {"id": "125"}]},
+                         {"id": "segid",
+                          "segment": [{"id": "text1"},
+                                      {"id": "Atext"}]}],
+                "geo": {},
+                "id": "localid"},
+       "userAgent": "Mozilla/5.0 (Linux; Android 4.1.2; DROID RAZR Build/9.8.2O-72_VZW-16) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31",
+       "userIds": {"prov": "somid",
+                   "xchg": "localid"}};
+
+var segmentsTest = {
+    topic: function() {
+        return new brm.BidRequest(JSON.stringify(requestWithSegments),
+                                  "datacratic");
+    },
+    checkSegments: function(x) {
+        var segments = x.segments;
+        var result = {};
+        assert("100" in segments,
+               "'100' must be present in segment list");
+        assert("segid" in segments,
+               "'segid' must be present in segment list");
+
+        var seg0 = x.segments["BLA"];
+        assert(seg0 == undefined, "bad1");
+
+        var seg100 = x.segments["100"];
+        assert(seg100 != undefined, "segment['100'] is undefined?");
+        seg100 = x.segments[100];
+        assert(seg100 != undefined, "segment[100] is undefined?");
+        var seg100Values = {};
+
+        for (var i = 0; i < seg100.toArray().length; i++) {
+            seg100Values[seg100[i]] = true;
+        }
+        assert("1" in seg100Values,
+               "'1' must be present in segments['100']");
+        assert("43" in seg100Values,
+               "'43' must be present in segments['100']");
+        assert("125" in seg100Values,
+               "'125' must be present in segments['100']");
+
+        var segid = x.segments["segid"];
+        assert(segid != undefined, "segments['segid'] is undefined?");
+        var segidValues = {};
+        for (var i = 0; i < segid.toArray().length; i++) {
+            segidValues[segid[i]] = true;
+        }
+        assert("text1" in segidValues,
+               "'text1' must be present in segments['segid']");
+        assert("Atext" in segidValues,
+               "'Atext' must be present in segments['segid']");
+    }
+};
+
+
+var tests = {
+    'segments': [ segmentsTest ]
+};
+
+vows.describe('rtb_bid_request_segments_test').addVows(tests).export(module);

--- a/testing/testing.mk
+++ b/testing/testing.mk
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------#
 
 $(eval $(call vowscoffee_test,bid_request_js_test,bid_request))
+$(eval $(call vowsjs_test,bid_request_js_segments_test,bid_request))
 $(eval $(call test,agent_configuration_test,rtb_router bidding_agent,boost))
 $(eval $(call test,augmentation_list_test,rtb,boost))
 $(eval $(call test,historical_bid_request_test,bid_request,boost))


### PR DESCRIPTION
Accessing segments with numeric keys always fail due to the fact that such keys are always converted to numeric values. This patch fixes the behaviour of this wrapper in order to return a proper object instead of "undefined".
