### PR TITLE
fix for mock_exchange winprice amount

### DIFF
--- a/testing/mock_exchange.cc
+++ b/testing/mock_exchange.cc
@@ -355,7 +355,7 @@ MockExchange::Worker::isWin(const BidRequest&, const Bid& bid)
     if (rng.random01() >= 0.1)
         return make_pair(false, Amount());
 
-    return make_pair(true, MicroUSD(bid.maxPrice * rng.random01()));
+    return make_pair(true, MicroUSD_CPM(bid.maxPrice * rng.random01()));
 }
 
 


### PR DESCRIPTION
We should use `MicroUSD_CPM` because `FixedPriceBiddingAgent` use it

```
            // Create a 0.0001$ CPM bid with our available creative.
            // Note that by default, the bid price is set to 0 which indicates
            // that we don't wish to bid on the given spot.
            bid.bid(availableCreative, MicroUSD_CPM(10000));
```

otherwise `winPrice` can be greater than `bidPrice`
