### PR TITLE
Segment.id declared as std::string to improve parsing time

### DIFF
--- a/openrtb/openrtb.h
+++ b/openrtb/openrtb.h
@@ -1088,7 +1088,7 @@ struct Device {
     specified, it should be considered unknown.
 */
 struct Segment {
-    Id id;                         ///< Segment ID
+    string id;                         ///< Segment ID
     string name;                   ///< Segment name
     string value;                  ///< Segment value
     TaggedFloat segmentusecost;    ///< Cost of using segment in CPM

--- a/plugins/bid_request/openrtb_bid_request.cc
+++ b/plugins/bid_request/openrtb_bid_request.cc
@@ -177,8 +177,8 @@ fromOpenRtb(OpenRTB::BidRequest && req,
 
             vector<string> values;
             for (auto & v: d.segment) {
-                if (v.id)
-                    values.push_back(v.id.toString());
+                if (!v.id.empty())
+                    values.push_back(v.id);
                 else if (!v.name.empty())
                     values.push_back(v.name);
             }


### PR DESCRIPTION
This patch improves the performance of large bid requests with many segments.
