### PR TITLE
Raise exception when trying to bid on unknown auction

### DIFF
--- a/plugins/bidding_agent/bidding_agent.cc
+++ b/plugins/bidding_agent/bidding_agent.cc
@@ -485,11 +485,13 @@ doBid(Id id, const Bids & bids, const Json::Value & jsonMeta, const WinCostModel
         lock_guard<mutex> guard (requestsLock);
 
         auto it = requests.find(id);
-        if (it != requests.end()) {
-            beforeSend = it->second.timestamp;
-            fromRouter = it->second.fromRouter;
-            requests.erase(it);
+        if (it == requests.end()) {
+            throw ML::Exception("Unknown bid id");
         }
+
+        beforeSend = it->second.timestamp;
+        fromRouter = it->second.fromRouter;
+        requests.erase(it);
     }
     if (fromRouter.empty()) return;
 


### PR DESCRIPTION
Bids that are placed on an unknown auction id are silently ignored. Raise an exception instead.
