### PR TITLE
Adx user properties fix

### DIFF
--- a/plugins/exchange/adx_exchange_connector.cc
+++ b/plugins/exchange/adx_exchange_connector.cc
@@ -479,8 +479,7 @@ parseBidRequest(HttpAuctionHandler & connection,
 
     if (gbr.has_cookie_age_seconds())
     {
-        // TODO should be set on br.user.ext
-        br.ext.atStr("user.ext.cookie_age_seconds") = gbr.cookie_age_seconds();
+        br.user->ext.atStr("cookie_age_seconds") = gbr.cookie_age_seconds();
     }
 
     // TODO: BidRequest.cookie_version


### PR DESCRIPTION
I suggest the following two patches to the adx exchange connector:
1. Store the `cookie_age_seconds` value in the `user.ext` field which has become available in OpenRTB 2.1 and which has been merged to master recently.
2. Store the hex-representation of `hosted_match_data` as `user.buyeruid`, since the canonical use case for `hosted_match_data` is cookie-matching where on other exchanges one usually just drops the own user id in the exchange's match tables.
