### PR TITLE
Remove openrtb auction type check

### DIFF
--- a/plugins/bid_request/openrtb_bid_request.cc
+++ b/plugins/bid_request/openrtb_bid_request.cc
@@ -26,9 +26,6 @@ fromOpenRtb(OpenRTB::BidRequest && req,
 {
     std::unique_ptr<BidRequest> result(new BidRequest());
 
-    if (req.at.value() != OpenRTB::AuctionType::SECOND_PRICE)
-        throw ML::Exception("TODO: support 1st price auctions in OpenRTB");
-
     result->auctionId = std::move(req.id);
     result->auctionType = AuctionType::SECOND_PRICE;
     result->timeAvailableMs = req.tmax.value();


### PR DESCRIPTION
I believe there is no logic that mandates that rtbkit only works with second-price auctions. We want to use rtbkit in other types of auctions. Can we remove this check?
