### PR TITLE
standard events descriptions and corresponding ValueDescription classes

### DIFF
--- a/plugins/adserver/adserver.mk
+++ b/plugins/adserver/adserver.mk
@@ -11,6 +11,18 @@ $(eval $(call library,adserver_connector, \
 	$(LIBADSERVERCONNECTOR_SOURCES),  \
 	$(LIBADSERVERCONNECTOR_LINK)))
 
+
+# standard events
+LIBSTANDARDEVENTS_SOURCES := \
+	standard_value_descriptions.cc
+
+LIBSTANDARDEVENTS_LINK := \
+	value_description types
+
+$(eval $(call library,standard_events, \
+	$(LIBSTANDARDEVENTS_SOURCES),  \
+	$(LIBSTANDARDEVENTS_LINK)))
+
 $(eval $(call library,mock_adserver,mock_adserver_connector.cc mock_win_source.cc,adserver_connector bid_test_utils))
 $(eval $(call library,standard_adserver,standard_adserver_connector.cc standard_win_source.cc,adserver_connector bid_test_utils))
 $(eval $(call program,adserver_runner,adserver_connector boost_program_options services))

--- a/plugins/adserver/standard_events.h
+++ b/plugins/adserver/standard_events.h
@@ -1,0 +1,90 @@
+/* standard_events.h                                                 -*-C++-*-
+   Wolfgang Sourdeau, September 2013
+   Copyright (C) 2013 Datacratic.  All rights reserved.
+
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "soa/types/id.h"
+
+
+namespace RTBKIT {
+
+struct StandardWin {
+    StandardWin()
+        : timestamp(-1.0), bidTimestamp(-1.0), winPrice(-1.0), dataCost(-1.0)
+    {}
+
+    /* timestamp of the win event */
+    double timestamp;
+
+    /* winning auction */
+    double bidTimestamp;
+    Datacratic::Id auctionId;
+    Datacratic::Id adSpotId;
+    std::vector<Datacratic::Id> userIds;
+
+    /* prices */
+    double winPrice;
+    double dataCost;
+
+    Datacratic::Id accountId;
+    Json::Value meta;
+};
+
+struct StandardExternalWin {
+    StandardExternalWin()
+        : timestamp(-1.0), winPrice(-1.0), dataCost(-1.0)
+    {}
+
+    double timestamp;
+    double bidTimestamp;
+    Datacratic::Id auctionId;
+    Datacratic::Id adSpotId;
+    std::vector<Datacratic::Id> userIds;
+    double winPrice;
+    double dataCost;
+
+    /* original bid request */
+    Json::Value bidRequest;
+};
+
+struct StandardClick {
+    StandardClick()
+        : timestamp(-1.0), bidTimestamp(-1.0)
+    {}
+
+    double timestamp;
+
+    Datacratic::Id auctionId;
+    Datacratic::Id adSpotId;
+    std::vector<Datacratic::Id> userIds;
+
+    double bidTimestamp;
+
+    std::string event; // "click"
+};
+
+struct StandardConversion {
+    StandardConversion()
+        : timestamp(-1.0), bidTimestamp(-1.0), payout(-1.0)
+    {}
+
+    double timestamp;
+
+    double bidTimestamp;
+    Datacratic::Id auctionId;
+    Datacratic::Id adSpotId;
+    std::vector<Datacratic::Id> userIds;
+
+    double payout;
+    
+    std::string event; // "conversion"
+};
+
+
+} // namespace RTBKIT

--- a/plugins/adserver/standard_value_descriptions.cc
+++ b/plugins/adserver/standard_value_descriptions.cc
@@ -1,0 +1,66 @@
+/* value_description.cc                                            -*- C++ -*-
+   Wolfgang Sourdeau, September 2013
+   Copyright (C) 2013 Datacratic.  All rights reserved.
+
+*/
+
+#include "soa/types/basic_value_descriptions.h"
+
+#include "value_description.h"
+
+using namespace std;
+using namespace RTBKIT;
+
+namespace Datacratic {
+
+DefaultDescription<StandardWin>::
+DefaultDescription()
+{
+    addField("timestamp", &StandardWin::timestamp, "");
+    addField("bidTimestamp", &StandardWin::bidTimestamp, "");
+    addField("auctionId", &StandardWin::auctionId, "");
+    addField("adSpotId", &StandardWin::adSpotId, "");
+    addField("userIds", &StandardWin::userIds, "");
+    addField("winPrice", &StandardWin::winPrice, "");
+    addField("dataCost", &StandardWin::dataCost, "");
+    addField("accountId", &StandardWin::accountId, "");
+    addField("winMeta", &StandardWin::meta, "");
+}
+
+DefaultDescription<StandardExternalWin>::
+DefaultDescription()
+{
+    addField("timestamp", &StandardExternalWin::timestamp, "");
+    addField("bidTimestamp", &StandardExternalWin::bidTimestamp, "");
+    addField("auctionId", &StandardExternalWin::auctionId, "");
+    addField("adSpotId", &StandardExternalWin::adSpotId, "");
+    addField("userIds", &StandardExternalWin::userIds, "");
+    addField("winPrice", &StandardExternalWin::winPrice, "");
+    addField("dataCost", &StandardExternalWin::dataCost, "");
+    addField("bidRequest", &StandardExternalWin::bidRequest, "");
+}
+
+DefaultDescription<StandardClick>::
+DefaultDescription()
+{
+    addField("timestamp", &StandardClick::timestamp, "");
+    addField("bidTimestamp", &StandardClick::bidTimestamp, "");
+    addField("auctionId", &StandardClick::auctionId, "");
+    addField("adSpotId", &StandardClick::adSpotId, "");
+    addField("userIds", &StandardClick::userIds, "");
+    addField("event", &StandardClick::event, "");
+}
+
+DefaultDescription<StandardConversion>::
+DefaultDescription()
+{
+    addField("timestamp", &StandardConversion::timestamp, "");
+    addField("bidTimestamp", &StandardConversion::bidTimestamp, "");
+    addField("auctionId", &StandardConversion::auctionId, "");
+    addField("adSpotId", &StandardConversion::adSpotId, "");
+    addField("userIds", &StandardConversion::userIds, "");
+    addField("payout", &StandardConversion::payout, "");
+    addField("event", &StandardConversion::event, "");
+}
+
+} // namespace Datacratic

--- a/plugins/adserver/standard_value_descriptions.h
+++ b/plugins/adserver/standard_value_descriptions.h
@@ -1,0 +1,40 @@
+/* value_description.h                                             -*- C++ -*-
+   Wolfgang Sourdeau, September 2013
+   Copyright (C) 2013 Datacratic.  All rights reserved.
+
+*/
+
+#pragma once
+
+#include "soa/types/value_description.h"
+
+#include "standard_events.h"
+
+
+namespace Datacratic {
+
+template<>
+struct DefaultDescription<RTBKIT::StandardWin>
+    : public StructureDescription<RTBKIT::StandardWin> {
+    DefaultDescription();
+};
+
+template<>
+struct DefaultDescription<RTBKIT::StandardExternalWin>
+    : public StructureDescription<RTBKIT::StandardExternalWin> {
+    DefaultDescription();
+};
+
+template<>
+struct DefaultDescription<RTBKIT::StandardClick>
+    : public StructureDescription<RTBKIT::StandardClick> {
+    DefaultDescription();
+};
+
+template<>
+struct DefaultDescription<RTBKIT::StandardConversion>
+    : public StructureDescription<RTBKIT::StandardConversion> {
+    DefaultDescription();
+};
+
+} // namespace Datacratic


### PR DESCRIPTION
This patch adds description classes and corresponding ValueDescription classes for "Standard" adserver events, in order to enable fast json parsing of those events.
