### PR TITLE
Adds support for UTF-8 bid requests.

### DIFF
--- a/common/auction_events.h
+++ b/common/auction_events.h
@@ -38,7 +38,7 @@ struct SubmittedAuctionEvent {
     Date lossTimeout;              ///< Time at which a loss is to be assumed
     JsonHolder augmentations;      ///< Augmentations active
     std::shared_ptr<BidRequest> bidRequest;  ///< Bid request
-    std::string bidRequestStr;     ///< Bid request as string on the wire
+    Utf8String bidRequestStr;     ///< Bid request as string on the wire
     Auction::Response bidResponse; ///< Bid response that was sent
     std::string bidRequestStrFormat;  ///< Format of stringified request(i.e "datacratic")
 

--- a/core/post_auction/post_auction_loop.cc
+++ b/core/post_auction/post_auction_loop.cc
@@ -85,7 +85,7 @@ reconstituteFromString(const std::string & str)
     }
     bid.reconstitute(store);
 
-    if (bidRequestStr != "")
+    if (bidRequestStr != Utf8String(""))
         bidRequest.reset(BidRequest::parse(bidRequestStrFormat, bidRequestStr));
     else bidRequest.reset();
 }

--- a/core/post_auction/post_auction_loop.h
+++ b/core/post_auction/post_auction_loop.h
@@ -39,7 +39,7 @@ struct SubmissionInfo {
     }
 
     std::shared_ptr<BidRequest> bidRequest;
-    std::string bidRequestStr;
+    Utf8String bidRequestStr;
     std::string bidRequestStrFormat;
     JsonHolder augmentations;
     Auction::Response  bid;               ///< Bid we passed on
@@ -80,7 +80,7 @@ struct FinishedInfo {
     Id adSpotId;          ///< Spot ID from host
     int spotIndex;
     std::shared_ptr<BidRequest> bidRequest;  ///< What we bid on
-    std::string bidRequestStr;
+    Utf8String bidRequestStr;
     std::string bidRequestStrFormat;
     JsonHolder augmentations;
     std::set<Id> uids;                ///< All UIDs for this user


### PR DESCRIPTION
Change the bidRequestStr in SubmittedAuctionEvent, SubmissionInfo
and FinishedInfo from std::string to Datacratic::Utf8String.
This fixes an issue where the router would throw and exception
stating "Invalid character in JSON string" if the bid request
had non-ascii characters.
