### PR TITLE
Virtual default destructor to avoid compiler warning

### DIFF
--- a/common/testing/bid_request_synth.cc
+++ b/common/testing/bid_request_synth.cc
@@ -175,6 +175,8 @@ struct Node
     virtual Json::Value generate(GenerateCtx& ctx) const = 0;
     virtual void dump(ostream& stream) const = 0;
     virtual void load(Parse_Context& ctx) = 0;
+
+    virtual ~Node() = default;
 };
 
 


### PR DESCRIPTION
The warning was

```
./rtbkit/common/testing/bid_request_synth.cc: In destructor ‘RTBKIT::Synth::NodeObject::~NodeObject()’:
./rtbkit/common/testing/bid_request_synth.cc:267:26: error: deleting object of abstract class type ‘RTBKIT::Synth::Node’ which has non-virtual destructor will cause undefined behaviour [-Werror=delete-non-virtual-dtor]
             delete field.second;
                          ^
cc1plus: all warnings being treated as errors
```
