### PR TITLE
made default tmax 30ms and network default round trip time 20ms to make ...

### DIFF
--- a/plugins/exchange/openrtb_exchange_connector.cc
+++ b/plugins/exchange/openrtb_exchange_connector.cc
@@ -140,7 +140,7 @@ getTimeAvailableMs(HttpAuctionHandler & connection,
     static const std::string toFind = "\"tmax\":";
     std::string::size_type pos = payload.find(toFind);
     if (pos == std::string::npos)
-        return 10.0;
+        return 30.0;
     
     int tmax = atoi(payload.c_str() + pos + toFind.length());
     return tmax;


### PR DESCRIPTION
...sure that bid requests aren't rejected if tmax isn't specified in the bidrequest
