### PR TITLE
Adx adgroup_id support 

### DIFF
--- a/plugins/exchange/adx_exchange_connector.h
+++ b/plugins/exchange/adx_exchange_connector.h
@@ -97,6 +97,7 @@ struct AdXExchangeConnector: public HttpExchangeConnector {
         std::string buyer_creative_id_ ;            ///< Buyer Creative Id
         std::string html_snippet_;                  ///< landing Url
         std::string click_through_url_;             ///< Click
+        std::string adgroup_id_;                    ///< Ad Group Id
         std::unordered_set<int32_t> vendor_type_ ;  ///< Vendor Type
         std::unordered_set<int32_t> category_ ;     ///< Category
         std::unordered_set<int32_t> attribute_;     ///< Attribute


### PR DESCRIPTION
An agent can now set in the adx provider configuration the adGroupId
parameter, it is of type string and optional. If set on the config it
will always be set in the bid response if the matching bid request
had it declared for the given adslot match data, otherwise (there is
no match) the response will be filtered and a 'No Bid' will be
sent as a response.

For more info check this thread : https://groups.google.com/a/rtbkit.org/forum/#!topic/discuss/Sx5YkMuTaiQ
