### PR TITLE
Avoid temporary by-value copies of std::shared_ptr<BidRequest> during Au...

### DIFF
--- a/common/auction.cc
+++ b/common/auction.cc
@@ -219,7 +219,7 @@ Auction()
 Auction::
 Auction(ExchangeConnector * exchangeConnector,
         HandleAuction handleAuction,
-        std::shared_ptr<BidRequest> request,
+        const std::shared_ptr<BidRequest> & request,
         const std::string & requestStr,
         const std::string & requestStrFormat,
         Date start,

--- a/common/auction.h
+++ b/common/auction.h
@@ -48,7 +48,7 @@ struct Auction : public std::enable_shared_from_this<Auction> {
     
     Auction(ExchangeConnector * exchangeConnector,
             HandleAuction handleAuction,
-            std::shared_ptr<BidRequest> request,
+            const std::shared_ptr<BidRequest> & request,
             const std::string & requestStr,
             const std::string & requestStrFormat,
             Date start,

--- a/core/router/router.cc
+++ b/core/router/router.cc
@@ -738,7 +738,7 @@ inline std::string chomp(const std::string & s)
 std::shared_ptr<Auction>
 Router::
 injectAuction(Auction::HandleAuction onAuctionFinished,
-              std::shared_ptr<BidRequest> request,
+              const std::shared_ptr<BidRequest> & request,
               const std::string & requestStr,
               const std::string & requestStrFormat,
               double startTime,

--- a/core/router/router.h
+++ b/core/router/router.h
@@ -282,7 +282,7 @@ struct Router : public ServiceBase,
     */
     std::shared_ptr<Auction>
     injectAuction(Auction::HandleAuction onAuctionFinished,
-                  std::shared_ptr<BidRequest> request,
+                  const std::shared_ptr<BidRequest> & request,
                   const std::string & requestStr,
                   const std::string & requestStrFormat,
                   double startTime = 0.0,


### PR DESCRIPTION
...ction injection.  Auction correctly stores a by-value copy of std::shared_ptr<BidRequest>.

I believe this should be a safe optimization.  Please review js/rtb_router_js.cc@314: 'return args.This();'

I'm not familiar with this idiom, if @270: 'std::shared_ptr<BidRequest> request;' is guaranteed to outlive the call to router.injectAuction(...) then this should be a safe commit, otherwise, it should be rejected.
