### PR TITLE
Capture recordHit() metrics for all new auctions (total) and per exchange ...

### DIFF
--- a/common/auction.h
+++ b/common/auction.h
@@ -39,13 +39,13 @@ struct AuctionResponseDescription;
 */
 
 struct Auction : public std::enable_shared_from_this<Auction> {
-    
+
     /** Callback that's called once the auction is finished. */
     typedef boost::function<void (std::shared_ptr<Auction> auction)>
         HandleAuction;
 
     Auction();
-    
+
     Auction(ExchangeConnector * exchangeConnector,
             HandleAuction handleAuction,
             std::shared_ptr<BidRequest> request,
@@ -53,7 +53,7 @@ struct Auction : public std::enable_shared_from_this<Auction> {
             const std::string & requestStrFormat,
             Date start,
             Date expiry);
-    
+
     ~Auction();
 
     bool isZombie;  ///< Auction was externally cancelled
@@ -73,6 +73,8 @@ struct Auction : public std::enable_shared_from_this<Auction> {
     std::string requestStr;  ///< Stringified version of request
     std::string requestStrFormat;  ///< Format of stringified request
     std::string requestSerialized; ///< Serialized bid request (canonical)
+
+    const char * exchangeName() const { return request ? request->exchange.c_str() : "unknown"; }
 
     ///< AugmentationList for each augmentors.
     std::unordered_map<std::string, AugmentationList> augmentations;
@@ -236,7 +238,7 @@ struct Auction : public std::enable_shared_from_this<Auction> {
 
     /** Return a JSON representation of the response. */
     Json::Value getResponseJson(int spotNum) const;
-    
+
     /** Return all responses as JSON. */
     Json::Value getResponsesJson() const;
 
@@ -266,7 +268,7 @@ struct Auction : public std::enable_shared_from_this<Auction> {
                 throw ML::Exception("invalid spot number");
             return !responses[spotNum].empty();
         }
-        
+
         bool hasError() const
         {
             return !error.empty();

--- a/core/router/router.cc
+++ b/core/router/router.cc
@@ -1226,13 +1226,10 @@ preprocessAuction(const std::shared_ptr<Auction> & auction)
         return std::shared_ptr<AugmentationInfo>();
     }
 
-    const string & exchange = auction->request->exchange;
-
     /* Parse out the adimp. */
     const vector<AdSpot> & imp = auction->request->imp;
 
-    recordCount(imp.size(), "exchange.%s.imp", exchange.c_str());
-    recordHit("exchange.%s.requests", exchange.c_str());
+    recordCount(imp.size(), "exchange.%s.imp", auction->exchangeName());
 
     // List of possible agents per round robin group
     std::map<string, GroupPotentialBidders> groupAgents;
@@ -2300,6 +2297,9 @@ void
 Router::
 onNewAuction(std::shared_ptr<Auction> auction)
 {
+    recordHit("auctions");
+    recordHit("exchange.%s.requests", auction->exchangeName());
+
     if (!monitorClient.getStatus()) {
         Date now = Date::now();
 
@@ -2316,6 +2316,7 @@ onNewAuction(std::shared_ptr<Auction> auction)
         if (slowModeCount > 100) {
             /* we only let the first 100 auctions take place each second */
             recordHit("monitor.ignoredAuctions");
+            recordHit("exchange.%s.ignoredRequests", auction->exchangeName());
             auction->finish();
             return;
         }


### PR DESCRIPTION
...as well as ignored per exchange.  Refactor to introduce a helper function in Auction: `const char * exchangeName() const`.

Proposal - follow up with another branch to harmonize the metric naming convention:
- `"bid"` -> `"bids"`
- `"exchange.*.requests"` -> `"exchange.*.auctions"`
- `"exchange.*.ignoredRequests"` -> `"exchange.*.ignoredAuctions"`
