### PR TITLE
Make connecting to the postAuctionLoop configurable through the commandline.

### DIFF
--- a/core/router/router.cc
+++ b/core/router/router.cc
@@ -2719,18 +2719,20 @@ submitToPostAuctionService(std::shared_ptr<Auction> auction,
                         + "-" + bid.agent;
     banker->detachBid(bid.account, auctionKey);
 
-    SubmittedAuctionEvent event;
-    event.auctionId = auction->id;
-    event.adSpotId = adSpotId;
-    event.lossTimeout = auction->lossAssumed;
-    event.augmentations = auction->agentAugmentations[bid.agent];
-    event.bidRequest = auction->request;
-    event.bidRequestStr = auction->requestStr;
-    event.bidRequestStrFormat = auction->requestStrFormat ;
-    event.bidResponse = bid;
+    if (postAuctionEndpoint.isConnected()) {
+        SubmittedAuctionEvent event;
+        event.auctionId = auction->id;
+        event.adSpotId = adSpotId;
+        event.lossTimeout = auction->lossAssumed;
+        event.augmentations = auction->agentAugmentations[bid.agent];
+        event.bidRequest = auction->request;
+        event.bidRequestStr = auction->requestStr;
+        event.bidRequestStrFormat = auction->requestStrFormat ;
+        event.bidResponse = bid;
 
-    Message<SubmittedAuctionEvent> message(std::move(event));
-    postAuctionEndpoint.sendMessage("AUCTION", message.toString());
+        Message<SubmittedAuctionEvent> message(std::move(event));
+        postAuctionEndpoint.sendMessage("AUCTION", message.toString());
+    }
 
     if (auction.unique()) {
         auctionGraveyard.tryPush(auction);

--- a/core/router/router_runner.cc
+++ b/core/router/router_runner.cc
@@ -41,6 +41,7 @@ RouterRunner::
 RouterRunner() :
     exchangeConfigurationFile("examples/router-config.json"),
     lossSeconds(15.0),
+    noPostAuctionLoop(false),
     logAuctions(false),
     logBids(false),
     maxBidPrice(200)
@@ -58,6 +59,8 @@ doOptions(int argc, char ** argv,
     router_options.add_options()
         ("loss-seconds,l", value<float>(&lossSeconds),
          "number of seconds after which a loss is assumed")
+        ("no-post-auction-loop", bool_switch(&noPostAuctionLoop),
+         "don't connect to the post auction loop")
         ("log-uri", value<vector<string> >(&logUris),
          "URI to publish logs to")
         ("exchange-configuration,x", value<string>(&exchangeConfigurationFile),
@@ -99,8 +102,10 @@ init()
 
     exchangeConfig = loadJsonFromFile(exchangeConfigurationFile);
 
+    auto connectPostAuctionLoop = !noPostAuctionLoop;
     router = std::make_shared<Router>(proxies, serviceName, lossSeconds,
-                                      true, logAuctions, logBids,
+                                      connectPostAuctionLoop,
+                                      logAuctions, logBids,
                                       USD_CPM(maxBidPrice));
     router->init();
 

--- a/core/router/router_runner.h
+++ b/core/router/router_runner.h
@@ -30,6 +30,7 @@ struct RouterRunner {
     //std::string routerConfigurationFile;
     std::string exchangeConfigurationFile;
     float lossSeconds;
+    bool noPostAuctionLoop;
 
     bool logAuctions;
     bool logBids;


### PR DESCRIPTION
The `Router()` constructor accepts an argument `connectPostAuctionLoop` which is hard-coded to `true` in the `router_runner`. This patch adds a `--no-post-auction-loop` commandline option to change the value of `connectPostAuctionLoop` to `false.

The patch also includes a fix to `Router::submitToPostAuctionService` that prevents sending messages to the `postAuctionEndpoint` zmq socket if the `postAuctionEndpoint` has not been connected.
