### PR TITLE
added user agent - ip hash as a parameter in the bid request. can be use...

### DIFF
--- a/common/bid_request.h
+++ b/common/bid_request.h
@@ -278,6 +278,7 @@ struct BidRequest {
     std::string protocolVersion;  ///< What protocol version, eg OpenRTB
     std::string exchange;
     std::string provider;
+    std::string userAgentIPHash;  ///< Concatenation of the user agent and IP hashed
 
     /* The following fields indicate the contents of the OpenRTB bid request
        that is being processed.

--- a/plugins/exchange/adx_exchange_connector.cc
+++ b/plugins/exchange/adx_exchange_connector.cc
@@ -595,17 +595,39 @@ parseBidRequest(HttpAuctionHandler & connection,
     	br.user.emplace();
     }
 
-    if (gbr.has_google_user_id())
+    bool has_google_user_id = gbr.has_google_user_id();
+    bool has_user_agent = gbr.has_user_agent();
+
+    if (has_google_user_id)
     {
     	// google_user_id
         // TODO: fix Id() so that it can parse 27 char Google ID into GOOG128
         // for now, fall back on STR type
     	br.user->id = Id (gbr.google_user_id());
+        br.userIds.add(br.user->id, ID_EXCHANGE);
     }
 
     if (gbr.has_hosted_match_data())
     {
         br.user->buyeruid = Id(binary_to_hexstr(gbr.hosted_match_data()));
+        // Provider ID is needed to map different bid requests to the same user
+        br.userIds.add(br.user->buyeruid, ID_PROVIDER);
+    }
+    else
+    {
+        if(has_google_user_id) {
+            // We'll use the google user id for the provider ID
+            br.userIds.add(br.user->id, ID_PROVIDER);
+        }
+        if (gbr.has_ip() && has_user_agent){
+            // Use a hashing function of IP + User Agent concatenation
+            br.userAgentIPHash = CityHash64((gbr.ip() + gbr.user_agent()).c_str(),(gbr.ip() + gbr.user_agent()).length());
+            br.userIds.add(Id(br.userAgentIPHash), ID_PROVIDER);
+        }
+        else {
+            // Set provider ID to 0
+            br.userIds.add(Id(0), ID_PROVIDER);
+        }
     }
 
     if (gbr.has_cookie_age_seconds())
@@ -614,7 +636,7 @@ parseBidRequest(HttpAuctionHandler & connection,
     }
 
     // TODO: BidRequest.cookie_version
-    if (gbr.has_user_agent())
+    if (has_user_agent)
     {
 
 #if 0
@@ -623,8 +645,9 @@ parseBidRequest(HttpAuctionHandler & connection,
         static sregex oe = sregex::compile("(,gzip\\(gfe\\))+$") ;
         device.ua = regex_replace (gbr.user_agent(), oe, string());
 #else
-        device.ua = gbr.user_agent();
+        device.ua = Utf8String(gbr.user_agent());
 #endif
+        br.userAgent = Utf8String(gbr.user_agent());
     }
 
     // See function comment.


### PR DESCRIPTION
...d to identify specific users if we dont get their user-id.

Also changed in adx exchange connector a way to get provider id.

It will base itself provider id -> user id -> ip / user agent hash -> fail. The reason for this is all those fields are listed as optional so having 2 back ups cannot hurt.
