### PR TITLE
patch to allows us to set the charset if supplied with the mimetype

### DIFF
--- a/plugins/bid_request/openrtb_bid_request.cc
+++ b/plugins/bid_request/openrtb_bid_request.cc
@@ -192,8 +192,8 @@ fromOpenRtb(OpenRTB::BidRequest && req,
         if (result->user->buyeruid)
             result->userIds.add(result->user->buyeruid, ID_PROVIDER);
         else if(req.device && !req.device->ip.empty() && !req.device->ua.empty()) {
-            result->userAgentIPHash = CityHash64((req.device->ip + req.device->ua.extractAscii()).c_str(),
-                                              (req.device->ip + req.device->ua.extractAscii()).length());
+            const std::string &strToHash = (req.device->ip + req.device->ua.extractAscii());
+            result->userAgentIPHash = CityHash64(strToHash.c_str(), strToHash.length());
             result->userIds.add(Id(result->userAgentIPHash), ID_PROVIDER);
         }
         
@@ -207,8 +207,8 @@ fromOpenRtb(OpenRTB::BidRequest && req,
         // the user
 
         if(req.device && !req.device->ip.empty() && !req.device->ua.empty()) {
-            result->userAgentIPHash = CityHash64((req.device->ip + req.device->ua.extractAscii()).c_str(),
-                                              (req.device->ip + req.device->ua.extractAscii()).length());
+            const std::string &strToHash = (req.device->ip + req.device->ua.extractAscii());
+            result->userAgentIPHash = CityHash64(strToHash.c_str(), strToHash.length());
             result->userIds.add(Id(result->userAgentIPHash), ID_PROVIDER);
         }
         else

--- a/plugins/exchange/openrtb_exchange_connector.cc
+++ b/plugins/exchange/openrtb_exchange_connector.cc
@@ -14,7 +14,6 @@
 #include "soa/types/json_printing.h"
 #include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/tokenizer.hpp>
 #include "jml/utils/file_functions.h"
 #include "jml/arch/info.h"
 #include "jml/utils/rng.h"


### PR DESCRIPTION
1) patch to allows us to set the charset if supplied with the mimetype ex : application/json; charset=UTF-8 will now be accepted. the charset will not be used for now but eventually can.

2) set the ID_PROV : either with buyeruid, IP + user agent hash, or 0 if not available for openrtb.
