### PR TITLE
Adds urlencode filter to CreativeConfiguration

### DIFF
--- a/rtbkit/common/creative_configuration.h
+++ b/rtbkit/common/creative_configuration.h
@@ -126,6 +126,21 @@ public:
                     return value;
                 }
             },
+            {
+                "urlencode",
+                [](std::string& value) -> std::string&
+                {
+                    std::string result;
+                    for (auto c: value) {
+                        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+                            result += c;
+                        else result += ML::format("%%%02X", c);
+                    }
+
+                    value = std::move(result);
+                    return value;
+                }
+            },
         };
 
     }

--- a/rtbkit/testing/creative_configuration_test.cc
+++ b/rtbkit/testing/creative_configuration_test.cc
@@ -34,13 +34,15 @@ const std::string SNIPPET2 = "%{creative.name}";
 const std::string SNIPPET3 = "%{meta.test.coucou}";
 const std::string SNIPPET4 = "%{meta.filter#upper}";
 const std::string SNIPPET5 = "%{meta.filter#lower}";
+const std::string SNIPPET6 = "%{meta.filter#urlencode}";
 
 #define APPLY_ON_SNIPPETS(SNIPPET_FN)   \
     SNIPPET_FN(1, SNIPPET1)             \
     SNIPPET_FN(2, SNIPPET2)             \
     SNIPPET_FN(3, SNIPPET3)             \
     SNIPPET_FN(4, SNIPPET4)             \
-    SNIPPET_FN(5, SNIPPET5)
+    SNIPPET_FN(5, SNIPPET5)             \
+    SNIPPET_FN(6, SNIPPET6)
 
 const auto providerConfigSnippet = [&](){
     Json::Value conf;
@@ -169,6 +171,7 @@ BOOST_AUTO_TEST_CASE(test_snippet)
         const auto RESULT3 = "Test:Meta";
         const auto RESULT4 = "TEST:META";
         const auto RESULT5 = "test:meta";
+        const auto RESULT6 = "Test%3AMeta";
 
 #define APPLY_FN(NB, var) \
         BOOST_CHECK_EQUAL(RESULT ## NB, conf.expand(var, context));


### PR DESCRIPTION
This filter will perfom an urlencode over UTF8
and non UTF8 strings. Ie :

%{bidrequest.device.carrier#urlencode}
