### PR TITLE
Rtbkit 486

### DIFF
--- a/rtbkit/core/router/router.cc
+++ b/rtbkit/core/router/router.cc
@@ -983,7 +983,17 @@ checkDeadAgents()
                           "accounts.%s.timeSinceHeartbeat", account);
 
         if (timeSinceHeartbeat > 5.0) {
+          if (++info.status->suspected == 1) {
+            logMessage("GMP",
+                       Date::fromSecondsSinceEpoch(timeSinceHeartbeat).print(),
+                       format("SUSPECTED agent: %s"), it->first);
+          }
+          else {
+            // it is the second time in a row this is happening.
             info.status->dead = true;
+            logMessage("GMP",
+                       Date::fromSecondsSinceEpoch(timeSinceHeartbeat).print(),
+                       format("DEAD agent: %s"), it->first);
             if (it->second.numBidsInFlight() != 0) {
                 cerr << "agent " << it->first
                      << " has " << it->second.numBidsInFlight()
@@ -1005,6 +1015,12 @@ checkDeadAgents()
                 sendAgentMessage(it->first, "BYEBYE", getCurrentTime());
                 deadAgents.push_back(it);
             }
+          }
+        }
+        else {
+          // reset to normal, in case previouysly suspected
+          // : back to normal
+          info.status->suspected = 0;
         }
     }
 
@@ -1960,8 +1976,8 @@ doBid(const std::vector<std::string> & message)
             continue;
         }
 
-	recordCount(bid.price.value, "cummulatedBidPrice");
-	recordCount(price.value, "cummulatedAuthorizedPrice");
+        recordCount(bid.price.value, "cummulatedBidPrice");
+        recordCount(price.value, "cummulatedAuthorizedPrice");
 
         doProfileEvent(6, "banker");
 

--- a/rtbkit/core/router/router_types.h
+++ b/rtbkit/core/router/router_types.h
@@ -95,6 +95,7 @@ struct AgentStats {
 struct AgentStatus {
     AgentStatus()
         : dead(false), numBidsInFlight(0)
+	, suspected(0)
     {
         lastHeartbeat = Date::now();
     }
@@ -102,6 +103,7 @@ struct AgentStatus {
     bool dead;
     Date lastHeartbeat;
     size_t numBidsInFlight;
+    uint16_t suspected;
 };
 
 /// Information about a agent

--- a/rtbkit/js/bidding_agent_js.cc
+++ b/rtbkit/js/bidding_agent_js.cc
@@ -282,6 +282,7 @@ struct BiddingAgentJS :
 
         registerAsyncCallback(&RTBKIT::BiddingAgent::onPing, "onPing");
         registerAsyncCallback(&RTBKIT::BiddingAgent::onError, "onError");
+        registerAsyncCallback(&RTBKIT::BiddingAgent::onByebye, "onByebye");
     }
 };
 

--- a/rtbkit/plugins/bidding_agent/bidding_agent.cc
+++ b/rtbkit/plugins/bidding_agent/bidding_agent.cc
@@ -258,7 +258,16 @@ handleRouterMessage(const std::string & fromRouter,
         case hash_compile_time("DROPPEDBID") : handleResult(message, onDroppedBid); break;
         case hash_compile_time("GOTCONFIG") : /* no-op */ ; break;
         case hash_compile_time("ERROR") : handleError(message, onError) ; break;
-        case hash_compile_time("BYEBYE") : /* no-op */; break;
+        case hash_compile_time("BYEBYE"): {
+             if (onByebye) {
+                 onByebye(fromRouter,Date::now());
+              }
+              else {
+                 cerr << "eviction notification received. agent should join again";
+                 recordHit("byebyeMessage");
+              }
+              break;
+        }
         case hash_compile_time("PING0") : {
             //cerr << "ping0: message " << message << endl;
 

--- a/rtbkit/plugins/bidding_agent/bidding_agent.h
+++ b/rtbkit/plugins/bidding_agent/bidding_agent.h
@@ -232,6 +232,16 @@ struct BiddingAgent : public ServiceBase, public MessageLoop {
      */
     ErrorCbFn onError;
 
+    typedef void (ByebyeCb) (const std::string& fromRouter,
+                             Date timestamp);
+    typedef boost::function<ByebyeCb> ByebyeCbFn;
+
+    /** Triggered whenever  router considers this agent as dead
+     */
+    ByebyeCbFn onByebye;
+
+
+
 private:
 
     /** Format of a message to a router. */


### PR DESCRIPTION
This PR:
1) add a suspicion mechanism to the router.  Now for an agent to be evicted from the router, it needs to be missing a heartbeat two consecutive times in a row.
2) add support for handling BYEBYE messages on the bidding_agent. 
