### PR TITLE
Make Regulations ("regs") into optional object instead of list in request

### DIFF
--- a/rtbkit/openrtb/openrtb.h
+++ b/rtbkit/openrtb/openrtb.h
@@ -1129,7 +1129,7 @@ struct BidRequest {
     std::vector<std::string> cur;                ///< Allowable currencies
     Datacratic::List<ContentCategory> bcat;        ///< Blocked advertiser categories (table 6.1)
     std::vector<Datacratic::UnicodeString> badv;           ///< Blocked advertiser domains
-    Datacratic::List<Regulations> regs; ///< Regulations Object list (OpenRTB 2.2)
+    Datacratic::Optional<Regulations> regs; ///< Regulations Object (OpenRTB 2.2)
     Json::Value ext;                   ///< Protocol extensions
     Json::Value unparseable;           ///< Unparseable fields get put here
 };


### PR DESCRIPTION
Was getting parsing errors complaining about expecting an array for regs.

Example of regs object in request:
"regs":{"coppa":1}

--------------------------[Exception thrown]---------------------------
time:   2014-09-04T19:12:43Z
type:   Datacratic::StructureDescriptionBase::Exception
pid:    11094; tid: 11243
what:   at .regs: Bid Request:1:859: at .regs: expected array of OpenRTB::Regulations
