### PR TITLE
Small bugbix for LatLongDeviceFilter

### DIFF
--- a/rtbkit/core/router/filters/static_filters.cc
+++ b/rtbkit/core/router/filters/static_filters.cc
@@ -269,7 +269,7 @@ bool LatLongDevFilter::checkLatLongPresent(
     if ( ! req.device) return false;
     if ( ! req.device->geo) return false;
     if ( req.device->geo->lat.val == std::numeric_limits<float>::quiet_NaN() ||
-         req.device->geo->lat.val == std::numeric_limits<float>::quiet_NaN() )
+         req.device->geo->lon.val == std::numeric_limits<float>::quiet_NaN() )
         return false;
     return true;
 }


### PR DESCRIPTION
Latitude was checked twice and longitude none. Now both are check (presence).
