### PR TITLE
return on empty message from agent

### DIFF
--- a/rtbkit/core/router/router.cc
+++ b/rtbkit/core/router/router.cc
@@ -870,8 +870,10 @@ handleAgentMessage(const std::vector<std::string> & message)
         const string & address = message[0];
         const string & request = message[1];
 
-        if (request.empty())
+        if (request.empty()) {
             returnErrorResponse(message, "null request field");
+            return;
+        }
 
         if (request == "CONFIG") {
             string configName = message.at(2);


### PR DESCRIPTION
If the message from the agent is empty, no reason to continue processing
