### PR TITLE
Allow use httpbanker on bidding agent ex

### DIFF
--- a/rtbkit/examples/bidding_agent_ex.cc
+++ b/rtbkit/examples/bidding_agent_ex.cc
@@ -64,7 +64,7 @@ struct FixedPriceBiddingAgent :
 	    budgetController.setApplicationLayer(make_application_layer<ZmqLayer>(getServices()));
 	    budgetController.start();
 	} else {
-	    auto bankerUri = getServices()->bankerUri;
+	    //auto bankerUri = getServices()->bankerUri;
 	    ExcCheck(!bankerUri.empty(), "the banker-uri must be specified in the bootstrap.json");
 	    ExcCheck(httpActiveConnections > 0, "The number of active http connections must be > 0");
 	    std::stringstream ss;


### PR DESCRIPTION
if one wants to use the http banker then one needs to add the ability for the example/ bidding_agent_ex to have a connection to the master banker to control pacing. 
This change is disabled by default so it will not break the bidding_agent_ex provided by default out of the box.
