### PR TITLE
Bugfix : router crash cause of macro expander  

### DIFF
--- a/rtbkit/common/creative_configuration.h
+++ b/rtbkit/common/creative_configuration.h
@@ -83,8 +83,13 @@ public:
 
         {
             "bidrequest.user.id",
-            [](const Context& ctx)
-            { return ctx.bidrequest.user->id.toString(); }
+            [](const Context& ctx) -> std::string
+            {
+                if ( ctx.bidrequest.user){
+                    return ctx.bidrequest.user->id.toString();
+                }
+                return "";
+            }
         },
 
         {


### PR DESCRIPTION
When the macro expander tries to expand the macro bidrequest.user.id, it does not check that the user object is present in the bid request. So, when that macro is present and it needs to be expanded and the bidrequest->user object is not present, the router crashes.