### PR TITLE
smaato exchange connector

### DIFF
--- a/rtbkit/plugins/exchange/exchange.mk
+++ b/rtbkit/plugins/exchange/exchange.mk
@@ -12,6 +12,7 @@ $(eval $(call library,exchange,$(LIBRTB_EXCHANGE_SOURCES),$(LIBRTB_EXCHANGE_LINK
 $(eval $(call library,openrtb_exchange,openrtb_exchange_connector.cc,exchange bid_test_utils openrtb_bid_request))
 $(eval $(call library,rubicon_exchange,rubicon_exchange_connector.cc,openrtb_exchange))
 $(eval $(call library,mopub_exchange,mopub_exchange_connector.cc,openrtb_exchange))
+$(eval $(call library,smaato_exchange,smaato_exchange_connector.cc,openrtb_exchange))
 $(eval $(call library,bidswitch_exchange,bidswitch_exchange_connector.cc,openrtb_exchange))
 $(eval $(call library,nexage_exchange,nexage_exchange_connector.cc,openrtb_exchange))
 $(eval $(call library,appnexus_exchange,appnexus_exchange_connector.cc,exchange bid_test_utils appnexus_bid_request))

--- a/rtbkit/plugins/exchange/smaato_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/smaato_exchange_connector.cc
@@ -2,8 +2,6 @@
    Matthieu Labour, December 2014
    Copyright (c) 2014 Datacratic.  All rights reserved. */
 
-#include <thread>
-
 
 #include "smaato_exchange_connector.h"
 
@@ -131,7 +129,6 @@ parseBidRequest(HttpAuctionHandler & connection,
         if(verbose->second == "1") {
             if(!result->auctionId.notNull()) {
                 connection.sendErrorResponse("MISSING_ID", "The bid request requires the 'id' field");
-		std::cout << __FILE__ << ":" << __LINE__ << " missing id" << std::endl;
                 return none;
             }
         }
@@ -209,7 +206,6 @@ void getAttr(ExchangeConnector::ExchangeCompatibility & result,
 ExchangeConnector::ExchangeCompatibility
   SmaatoExchangeConnector::
   getCreativeCompatibility(const Creative & creative, bool includeReasons) const {
-  std::cout << __FILE__ << ":" << __LINE__ << " getCreativeCompatibility includeReasons=" << includeReasons << std::endl;
     ExchangeCompatibility result;
     result.setCompatible();
     
@@ -236,7 +232,6 @@ ExchangeConnector::ExchangeCompatibility
       // now go through the spots.
       for (const auto& spot: request.imp) {
           //const auto& mime_types = spot.banner->mimes;
-	std::cout << __FILE__ << ":" << __LINE__ << " spot=" << spot.toJson() << std::endl;
 	for (const auto& mimeType : spot.banner->mimes) { 
               if (std::find(crinfo->mimeTypes.begin(), crinfo->mimeTypes.end(), mimeType.type)
                       != crinfo->mimeTypes.end()) {

--- a/rtbkit/plugins/exchange/smaato_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/smaato_exchange_connector.cc
@@ -1,0 +1,321 @@
+/* smaato_exchange_connector.cc
+   Matthieu Labour, December 2014
+   Copyright (c) 2014 Datacratic.  All rights reserved. */
+
+#include <thread>
+
+
+#include "smaato_exchange_connector.h"
+
+#include "rtbkit/plugins/bid_request/openrtb_bid_request_parser.h"
+#include "rtbkit/plugins/exchange/http_auction_handler.h"
+#include "rtbkit/core/agent_configuration/agent_config.h"
+#include "rtbkit/openrtb/openrtb_parsing.h"
+#include "soa/types/json_printing.h"
+#include "soa/service/logs.h"
+#include <boost/any.hpp>
+#include <boost/lexical_cast.hpp>
+#include "jml/utils/file_functions.h"
+
+ 
+using namespace std;
+using namespace Datacratic;
+
+namespace {
+Logging::Category smaatoExchangeConnectorTrace("Smaato Exchange Connector");
+Logging::Category smaatoExchangeConnectorError("[ERROR] Smaato Exchange Connector", smaatoExchangeConnectorTrace);
+}
+ 
+namespace RTBKIT  { 
+
+/*****************************************************************************/
+/* MOPUB EXCHANGE CONNECTOR                                                */
+/*****************************************************************************/
+
+std::string SmaatoExchangeConnector::nobid = "nobid";
+
+SmaatoExchangeConnector::
+SmaatoExchangeConnector(ServiceBase & owner, const std::string & name)
+    : OpenRTBExchangeConnector(owner, name) {
+    this->auctionResource = "/auctions";
+    this->auctionVerb = "POST";
+}
+
+SmaatoExchangeConnector::
+SmaatoExchangeConnector(const std::string & name,
+                       std::shared_ptr<ServiceProxies> proxies)
+    : OpenRTBExchangeConnector(name, proxies) {
+    this->auctionResource = "/auctions";
+    this->auctionVerb = "POST";
+}
+ 
+std::shared_ptr<BidRequest>
+SmaatoExchangeConnector::
+parseBidRequest(HttpAuctionHandler & connection,
+                const HttpHeader & header,
+                const std::string & payload)
+{
+    std::shared_ptr<BidRequest> none;
+
+    size_t found = header.queryParams.uriEscaped().find(SmaatoExchangeConnector::nobid);
+    if (found != string::npos) {
+      connection.dropAuction("nobid");
+      return none;
+    }   
+
+    // Check for JSON content-type
+    if (!header.contentType.empty()) {
+        static const std::string delimiter = ";";
+
+        std::string::size_type posDelim = header.contentType.find(delimiter);
+        std::string content;
+
+        if(posDelim == std::string::npos)
+            content = header.contentType;
+        else {
+            content = header.contentType.substr(0, posDelim);
+            #if 0
+            std::string charset = header.contentType.substr(posDelim, header.contentType.length());
+            #endif
+        }
+
+        if(content != "application/json") {
+            connection.sendErrorResponse("UNSUPPORTED_CONTENT_TYPE", "The request is required to use the 'Content-Type: application/json' header");
+            return none;
+        }
+    }
+    else {
+        connection.sendErrorResponse("MISSING_CONTENT_TYPE_HEADER", "The request is missing the 'Content-Type' header");
+        return none;
+    }
+
+    // Check for the x-openrtb-version header
+    auto it = header.headers.find("x-openrtb-version");
+    if (it == header.headers.end()) {
+        connection.sendErrorResponse("MISSING_OPENRTB_HEADER", "The request is missing the 'x-openrtb-version' header");
+        return none;
+    }
+
+    // Check that it's version 2.0
+    std::string openRtbVersion = it->second;
+    if (openRtbVersion != "2.0") {
+        connection.sendErrorResponse("UNSUPPORTED_OPENRTB_VERSION", "The request is required to be using version 2.0 of the OpenRTB protocol but requested " + openRtbVersion);
+        return none;
+    }
+
+    if(payload.empty()) {
+        this->recordHit("error.emptyBidRequest");
+        connection.sendErrorResponse("EMPTY_BID_REQUEST", "The request is empty");
+        return none;
+    }
+
+    // Parse the bid request
+    std::shared_ptr<BidRequest> result;
+    try {
+        ML::Parse_Context context("Bid Request", payload.c_str(), payload.size());
+        result.reset(OpenRTBBidRequestParser::openRTBBidRequestParserFactory(openRtbVersion)->parseBidRequest(context,
+                                                                                              exchangeName(),
+                                                                                              exchangeName()));
+    }
+    catch(ML::Exception const & e) {
+        this->recordHit("error.parsingBidRequest");
+        throw;
+    }
+    catch(...) {
+        throw;
+    }
+
+    // Check if we want some reporting
+    auto verbose = header.headers.find("x-openrtb-verbose");
+    if(header.headers.end() != verbose) {
+        if(verbose->second == "1") {
+            if(!result->auctionId.notNull()) {
+                connection.sendErrorResponse("MISSING_ID", "The bid request requires the 'id' field");
+		std::cout << __FILE__ << ":" << __LINE__ << " missing id" << std::endl;
+                return none;
+            }
+        }
+    }
+    
+
+
+    return result;
+}
+
+
+
+ExchangeConnector::ExchangeCompatibility
+SmaatoExchangeConnector::
+getCampaignCompatibility(const AgentConfig & config,
+                         bool includeReasons) const {
+    ExchangeCompatibility result;
+    result.setCompatible();
+
+    auto cpinfo = std::make_shared<CampaignInfo>();
+ 
+    const Json::Value & pconf = config.providerConfig["smaato"];
+ 
+    try {
+      cpinfo->seat = Id(pconf["seat"].asString());
+      if (!cpinfo->seat)
+	result.setIncompatible("providerConfig.smaato.seat is null",
+			       includeReasons);
+    } catch (const std::exception & exc) {
+        result.setIncompatible
+	  (string("providerConfig.smaato.seat parsing error: ")
+	   + exc.what(), includeReasons);
+        return result;
+    }
+    
+    result.info = cpinfo;
+    return result;
+  }
+
+namespace {
+
+using Datacratic::jsonDecode;
+ 
+/** Given a configuration field, convert it to the appropriate JSON */
+template<typename T>
+void getAttr(ExchangeConnector::ExchangeCompatibility & result,
+             const Json::Value & config,
+             const char * fieldName,
+             T & field,
+             bool includeReasons) {
+
+    try {
+        if (!config.isMember(fieldName)) {
+            result.setIncompatible
+            ("creative[].providerConfig.smaato." + string(fieldName)
+             + " must be specified", includeReasons);
+            return;
+        }
+
+        const Json::Value & val = config[fieldName];
+
+        jsonDecode(val, field);
+    } catch (const std::exception & exc) {
+        result.setIncompatible("creative[].providerConfig.smaato."
+                               + string(fieldName) + ": error parsing field: "
+                               + exc.what(), includeReasons);
+        return;
+    }
+}
+
+} // file scope
+
+
+ 
+ExchangeConnector::ExchangeCompatibility
+  SmaatoExchangeConnector::
+  getCreativeCompatibility(const Creative & creative, bool includeReasons) const {
+  std::cout << __FILE__ << ":" << __LINE__ << " getCreativeCompatibility includeReasons=" << includeReasons << std::endl;
+    ExchangeCompatibility result;
+    result.setCompatible();
+    
+    auto crinfo = std::make_shared<CreativeInfo>();
+    const Json::Value & pconf = creative.providerConfig["smaato"];
+    
+    getAttr(result, pconf, "adm", crinfo->adm, includeReasons);
+    getAttr(result, pconf, "nurl", crinfo->nurl, includeReasons);
+    getAttr(result, pconf, "adid", crinfo->adid, includeReasons);
+    getAttr(result, pconf, "adomain", crinfo->adomain, includeReasons);
+    getAttr(result, pconf, "mimeTypes", crinfo->mimeTypes, includeReasons);
+    result.info = crinfo;
+ 
+    return result;
+  }
+
+  bool
+  SmaatoExchangeConnector::
+  bidRequestCreativeFilter(const BidRequest & request,
+            const AgentConfig & config,
+            const void * info) const {
+      const auto crinfo = reinterpret_cast<const CreativeInfo*>(info);
+
+      // now go through the spots.
+      for (const auto& spot: request.imp) {
+          //const auto& mime_types = spot.banner->mimes;
+	std::cout << __FILE__ << ":" << __LINE__ << " spot=" << spot.toJson() << std::endl;
+	for (const auto& mimeType : spot.banner->mimes) { 
+              if (std::find(crinfo->mimeTypes.begin(), crinfo->mimeTypes.end(), mimeType.type)
+                      != crinfo->mimeTypes.end()) {
+                  this->recordHit ("blockedMime");
+                  return true;
+              }
+	}
+      }
+
+       return false;
+  }
+
+void
+SmaatoExchangeConnector::
+setSeatBid(Auction const & auction,
+           int spotNum,
+           OpenRTB::BidResponse & response) const {
+
+    const Auction::Data * current = auction.getCurrentData();
+
+    // Get the winning bid
+    auto & resp = current->winningResponse(spotNum);
+
+    // Find how the agent is configured.  We need to copy some of the
+    // fields into the bid.
+    const AgentConfig * config =
+        std::static_pointer_cast<const AgentConfig>(resp.agentConfig).get();
+
+    std::string en = exchangeName();
+
+    // Get the exchange specific data for this campaign
+    auto cpinfo = config->getProviderData<CampaignInfo>(en);
+
+    // Put in the fixed parts from the creative
+    int creativeIndex = resp.agentCreativeIndex;
+
+    auto & creative = config->creatives.at(creativeIndex);
+
+    // Get the exchange specific data for this creative
+    auto crinfo = creative.getProviderData<CreativeInfo>(en);
+
+    // Find the index in the seats array
+    int seatIndex = 0;
+    while(response.seatbid.size() != seatIndex) {
+        if(response.seatbid[seatIndex].seat == cpinfo->seat) break;
+        ++seatIndex;
+    }
+
+    // Create if required
+    if(seatIndex == response.seatbid.size()) {
+        response.seatbid.emplace_back();
+        response.seatbid.back().seat = cpinfo->seat;
+    }
+
+    // Get the seatBid object
+    OpenRTB::SeatBid & seatBid = response.seatbid.at(seatIndex);
+
+    // Add a new bid to the array
+    seatBid.bid.emplace_back();
+    auto & b = seatBid.bid.back();
+
+    // Put in the variable parts
+    b.cid = Id(resp.agent);
+    b.id = Id(auction.id, auction.request->imp[0].id);
+    b.impid = auction.request->imp[spotNum].id;
+    b.price.val = getAmountIn<CPM>(resp.price.maxPrice);
+    b.adm = crinfo->adm;
+    b.adomain = crinfo->adomain;
+    b.nurl = crinfo->nurl;
+}
+
+} // namespace RTBKIT
+ 
+namespace {
+  using namespace RTBKIT;
+ 
+  struct Init {
+    Init() {
+      ExchangeConnector::registerFactory<SmaatoExchangeConnector>();
+    }
+  } init;
+}

--- a/rtbkit/plugins/exchange/smaato_exchange_connector.h
+++ b/rtbkit/plugins/exchange/smaato_exchange_connector.h
@@ -1,0 +1,83 @@
+/* smaato_exchange_connector.h
+   Matthieu Labour, December 2014
+   Copyright (c) 2014 Datacratic.  All rights reserved. */
+
+#pragma once
+ 
+#include "rtbkit/plugins/exchange/openrtb_exchange_connector.h"
+ 
+namespace RTBKIT {
+
+/*****************************************************************************/
+/* SMAATO EXCHANGE CONNECTOR                                                */
+/*****************************************************************************/
+
+/** Exchange connector for Smaato.  This speaks their flavour of the
+    OpenRTB 2.1 protocol.
+*/
+struct SmaatoExchangeConnector: public OpenRTBExchangeConnector {
+    SmaatoExchangeConnector(ServiceBase & owner, const std::string & name);
+    SmaatoExchangeConnector(const std::string & name,
+                           std::shared_ptr<ServiceProxies> proxies);
+
+    static std::string nobid;
+ 
+    static std::string exchangeNameString() {
+      return "smaato";
+    }
+ 
+    virtual std::string exchangeName() const {
+      return exchangeNameString();
+    }
+
+    virtual std::shared_ptr<BidRequest>
+    parseBidRequest(HttpAuctionHandler & connection,
+                    const HttpHeader & header,
+                    const std::string & payload);
+
+
+    double getTimeAvailableMs(HttpAuctionHandler & handler,
+			      const HttpHeader & header,
+			      const std::string & payload) {
+      return 100.0;
+    }
+ 
+    double getRoundTripTimeMs(HttpAuctionHandler & handler,
+			      const HttpHeader & header) {
+      return 35.0;
+    }
+    
+    struct CampaignInfo {
+      Id seat;                ///< ID of the exchange seat
+    };
+
+    virtual ExchangeCompatibility
+    getCampaignCompatibility(const AgentConfig & config,
+                             bool includeReasons) const;
+
+    struct CreativeInfo {
+      Id adid;                ///< ID for ad to be service if bid wins 
+      std::string adm;        ///< Actual XHTML ad markup
+      std::string nurl;       ///< Win notice URL
+      std::vector<std::string> adomain; ///< Advertiser Domain
+      std::vector<std::string> mimeTypes; ///< MIME Types for this creative
+    };
+
+    virtual ExchangeCompatibility
+      getCreativeCompatibility(const Creative & creative, bool includeReasons) const;
+
+    virtual bool
+      bidRequestCreativeFilter(const BidRequest & request,
+                             const AgentConfig & config,
+                             const void * info) const;
+
+  private:
+    virtual void setSeatBid(Auction const & auction,
+                            int spotNum,
+                            OpenRTB::BidResponse & response) const;
+
+
+
+  };
+
+} // namespace RTBKit

--- a/rtbkit/plugins/exchange/testing/exchange_testing.mk
+++ b/rtbkit/plugins/exchange/testing/exchange_testing.mk
@@ -1,7 +1,7 @@
 # exchange_testing.mk
 
 $(eval $(call test,rubicon_exchange_connector_test,rubicon_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router cairomm-1.0 cairo sigc-2.0,boost manual))
-$(eval $(call test,smaato_exchange_connector_test,smaato_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router cairomm-1.0 cairo sigc-2.0,boost manual))
+$(eval $(call test,smaato_exchange_connector_test,smaato_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router sigc-2.0,boost))
 $(eval $(call test,gumgum_exchange_connector_test,gumgum_exchange bid_test_utils openrtb_bid_request bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,bidswitch_exchange_connector_test,bidswitch_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,bidswitch_exchange_connector_adx_test,bidswitch_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))

--- a/rtbkit/plugins/exchange/testing/exchange_testing.mk
+++ b/rtbkit/plugins/exchange/testing/exchange_testing.mk
@@ -1,6 +1,7 @@
 # exchange_testing.mk
 
 $(eval $(call test,rubicon_exchange_connector_test,rubicon_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router cairomm-1.0 cairo sigc-2.0,boost manual))
+$(eval $(call test,smaato_exchange_connector_test,smaato_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router cairomm-1.0 cairo sigc-2.0,boost manual))
 $(eval $(call test,gumgum_exchange_connector_test,gumgum_exchange bid_test_utils openrtb_bid_request bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,bidswitch_exchange_connector_test,bidswitch_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,bidswitch_exchange_connector_adx_test,bidswitch_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))

--- a/rtbkit/plugins/exchange/testing/smaato_bid_request.json
+++ b/rtbkit/plugins/exchange/testing/smaato_bid_request.json
@@ -1,0 +1,49 @@
+{
+  "at": 2,
+  "device":   {
+    "connectiontype": 0,
+    "devicetype": 1,
+    "geo":     {
+      "lat": 42.357777,
+      "lon": -71.06167,
+      "type": 3
+    },
+    "ip": "201.252.0.0",
+    "js": 0,
+    "make": "Apple",
+    "model": "iPhone",
+    "os": "iPhone OS",
+    "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16"
+  },
+  "ext": {"udi": {"idfa":"aaaaaaa"}},
+  "id": "CmWwWKXOee",
+  "imp": [  {
+    "banner":     {
+      "btype":       [
+        1,
+        3
+      ],
+      "h": 50,
+      "mimes":       [
+        "image/gif",
+        "image/jpeg",
+        "image/png"
+      ],
+      "w": 320
+    },
+    "bidfloor": 0,
+    "displaymanager": "SOMA",
+    "id": "1"
+  }],
+  "site":   {
+    "cat": ["IAB1"],
+    "domain": "www.jacksbar.co.uk",
+    "id": "0",
+    "name": "Jack Rabbit Slims",
+    "publisher": {"id": "6"}
+  },
+  "user":   {
+    "gender": "M",
+    "yob": 1980
+  }
+}

--- a/rtbkit/plugins/exchange/testing/smaato_exchange_connector_test.cc
+++ b/rtbkit/plugins/exchange/testing/smaato_exchange_connector_test.cc
@@ -1,0 +1,173 @@
+/* smaato_exchange_connector_test.cc
+   Exchange connector test for Smaato.
+   Matthieu Labour, 05 Decembre 2014
+   Copyright (c) 2014 Datacratic.  All rights reserved.
+*/
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <thread>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include "rtbkit/common/testing/exchange_source.h"
+#include "rtbkit/plugins/bid_request/openrtb_bid_request.h"
+#include "rtbkit/plugins/exchange/smaato_exchange_connector.h"
+#include "rtbkit/plugins/exchange/http_auction_handler.h"
+#include "rtbkit/core/router/router.h"
+#include "rtbkit/core/agent_configuration/agent_configuration_service.h"
+#include "rtbkit/core/banker/null_banker.h"
+#include "rtbkit/testing/test_agent.h"
+
+#include "jml/arch/info.h"
+
+#include <type_traits>
+
+
+using namespace RTBKIT;
+
+
+const std::string bid_sample_filename("rtbkit/plugins/exchange/testing/smaato_bid_request.json");
+
+
+std::string loadFile(const std::string & filename)
+{
+    ML::filter_istream stream(filename);
+
+    std::string result;
+
+    while (stream) {
+        std::string line;
+        getline(stream, line);
+        result += line + "\n";
+    }
+
+    return result;
+}
+
+BOOST_AUTO_TEST_CASE( test_smaato )
+{
+    std::shared_ptr<ServiceProxies> proxies(new ServiceProxies());
+
+    // The agent config service lets the router know how our agent is configured
+    AgentConfigurationService agentConfig(proxies, "config");
+    agentConfig.unsafeDisableMonitor();
+    agentConfig.init();
+    agentConfig.bindTcp();
+    agentConfig.start();
+
+    // We need a router for our exchange connector to work
+    Router router(proxies, "router");
+    router.unsafeDisableMonitor();  // Don't require a monitor service
+    router.init();
+
+    // Set a null banker that blindly approves all bids so that we can
+    // bid.
+    router.setBanker(std::make_shared<NullBanker>(true));
+
+    // Start the router up
+    router.bindTcp();
+    router.start();
+
+    // Create our exchange connector and configure it to listen on port
+    // 10002.  Note that we need to ensure that port 10002 is open on
+    // our firewall.
+    std::shared_ptr<SmaatoExchangeConnector> connector
+    (new SmaatoExchangeConnector("connector", proxies));
+
+    connector->configureHttp(1, -1, "0.0.0.0");
+    connector->start();
+    int port = connector->port();
+
+    connector->enableUntil(Date::positiveInfinity());
+
+    // Tell the router about the new exchange connector
+    router.addExchange(connector);
+
+    // This is our bidding agent, that actually calculates the bid price
+    TestAgent agent(proxies, "BOB");
+    agent.config.account = {"janCampaign", "janStrat"};
+    agent.config.maxInFlight = 20000;
+    Creative creative(320, 50, "Mobile50x320Image", 201);
+    agent.config.creatives.push_back(creative);
+    Creative creative2(320, 50, "Mobile50x320Text", 202);
+    agent.config.creatives.push_back(creative2);
+
+    std::string portName = std::to_string(port);
+    std::string hostName = ML::fqdn_hostname(portName) + ":" + portName;
+
+    agent.config.providerConfig["smaato"]["seat"] = "123";
+
+
+    // Configure the agent for bidding
+    for (auto & c: agent.config.creatives) {
+	    c.providerConfig["smaato"]["adid"] = "314";
+        c.providerConfig["smaato"]["adomain"][0] = "rtbkit.org";
+        c.providerConfig["smaato"]["crid"] = c.name;
+        c.providerConfig["smaato"]["iurl"] = "http://www.gnu.org";
+        c.providerConfig["smaato"]["adm"]
+            = "<ad xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"smaato_ad_v0.9.xsd\" modelVersion=\"0.9\"><imageAd><clickUrl>http://mysite.com/landingpages/mypage/</clickUrl><imgUrl>http://mysite.com/images/myad.jpg</imgUrl><width>" + std::to_string(c.format.width) + "</width><height>"+std::to_string(c.format.height)+"</height><toolTip>This is a tooltip text</toolTip><additionalText>Additional text to be displayed</additionalText><beacons><beacon>http://mysite.com/beacons/mybeacon1</beacon><beacon>http://mysite.com/beacons/mybeacon2</beacon></beacons></imageAd></ad>";
+	    c.providerConfig["smaato"]["nurl"] = "http://mywinurl.com/win?width=" + std::to_string(c.format.width) + "&height="+ std::to_string(c.format.height) + "&auction_price=${AUCTION_PRICE}&auction_id=${AUCTION_ID}&adspot_id=${AUCTION_IMP_ID}&AUCTION_BID_ID=${AUCTION_BID_ID}&AUCTION_SEATID=${AUCTION_SEAT_ID}&AUCTION_ADID=${AUCTION_AD_ID}";
+        c.providerConfig["smaato"]["mimeTypes"][0] = "image/png";
+    }
+
+
+    
+    agent.onBidRequest = [&] (
+                             double timestamp,
+                             const Id & id,
+                             std::shared_ptr<BidRequest> br,
+                             Bids bids,
+                             double timeLeftMs,
+                             const Json::Value & augmentations,
+    const WinCostModel & wcm) {
+
+        std::cerr << "************************ ON BID REQ\n";
+        Bid& bid = bids[0];
+
+        bid.bid(bid.availableCreatives[0], USD_CPM(1.234));
+
+        agent.doBid(id, bids, Json::Value(), wcm);
+        ML::atomic_inc(agent.numBidRequests);
+
+        std::cerr << "bid count=" << agent.numBidRequests << std::endl;
+    };
+
+    agent.init();
+    agent.start();
+    agent.configure();
+
+    ML::sleep(1.0);
+
+    // load bid json
+    std::string strJson = loadFile(bid_sample_filename);
+    std::cerr << strJson << std::endl;
+
+    // prepare request
+    NetworkAddress address(port);
+    BidSource source(address);
+
+    std::string httpRequest = ML::format(
+                                  "POST /auctions?testbid=bid HTTP/1.1\r\n"
+                                  "Content-Length: %zd\r\n"
+                                  "Content-Type: application/json\r\n"
+                                  "Connection: Keep-Alive\r\n"
+                                  "x-openrtb-version: 2.0\r\n"
+                                  "\r\n"
+                                  "%s",
+                                  strJson.size(),
+                                  strJson.c_str());
+
+    // and send it
+    source.write(httpRequest);
+    std::cerr << source.read() << std::endl;
+
+    BOOST_CHECK_EQUAL(agent.numBidRequests, 1);
+
+    proxies->events->dump(std::cerr);
+
+    router.shutdown();
+    agentConfig.shutdown();
+}


### PR DESCRIPTION
I have created a pull request for the Smaato Exchange Connector. I was able to successfully pass the smaato certification at http://dspportal.smaato.com/ 
This is a proposal for the Smaato Exchange Connector.

A few issues to keep in mind:

* Smaato has lots of creative sizes. One will need to configure lots of creatives in bidding_agent_ex.cc. I can make a bidding_agent_ex.cc available for Smaato if needed.

* Smaato sends WINS as GET requests. RTBKIT only allows WINS to be POST requests. This can be easily hacked by changing a few files in RTBKIT or by having NGINX in front of RTBKIT and turning Smaato WIN GET requests into POST requests.