### PR TITLE
Adding Static PMP Filter

### DIFF
--- a/rtbkit/core/agent_configuration/agent_config.cc
+++ b/rtbkit/core/agent_configuration/agent_config.cc
@@ -27,8 +27,8 @@ namespace RTBKIT {
 /*****************************************************************************/
 
 Creative::
-Creative(int width, int height, std::string name, int id)
-    : format(width, height), name(name), id(id)
+Creative(int width, int height, std::string name, int id, const std::string dealId)
+    : format(width, height), name(name), id(id), dealId(dealId)
 {
 }
 
@@ -50,6 +50,9 @@ fromJson(const Json::Value & val)
         id = val["id"].asInt();
     if (id == -1)
         throw ML::Exception("creatives require an ID to be specified");
+
+    if (val.isMember("dealId"))
+        dealId = val["dealId"].asString();
 
     providerConfig = val["providerConfig"];
 
@@ -91,6 +94,8 @@ toJson() const
         }
         result["segmentFilter"] = segmentInfo;
     }
+    if (!dealId.empty())
+        result["dealId"] = dealId;
 
     return result;
 }

--- a/rtbkit/core/agent_configuration/agent_config.h
+++ b/rtbkit/core/agent_configuration/agent_config.h
@@ -33,7 +33,8 @@ struct ExchangeConnector;
 /** Describes a creative that a agent has available. */
 
 struct Creative {
-    Creative(int width = 0, int height = 0, std::string name = "", int id = -1);
+    Creative(int width = 0, int height = 0, std::string name = "", int id = -1,
+            const std::string dealId = "");
 
     // Three samples that can be used for testing...
     static const Creative sampleLB;
@@ -80,6 +81,9 @@ struct Creative {
     IncludeExclude<std::string> languageFilter;
     IncludeExclude<CachedRegex<boost::u32regex, Datacratic::UnicodeString> > locationFilter;
     IncludeExclude<std::string> exchangeFilter;
+   
+    // Needed for PMP filter
+    std::string dealId;
 
     struct SegmentInfo {
 

--- a/rtbkit/core/router/filters/creative_filters.cc
+++ b/rtbkit/core/router/filters/creative_filters.cc
@@ -78,6 +78,7 @@ struct InitFilters
         RTBKIT::FilterRegistry::registerFilter<RTBKIT::CreativeExchangeNameFilter>();
         RTBKIT::FilterRegistry::registerFilter<RTBKIT::CreativeExchangeFilter>();
         RTBKIT::FilterRegistry::registerFilter<RTBKIT::CreativeSegmentsFilter>();
+        RTBKIT::FilterRegistry::registerFilter<RTBKIT::CreativePMPFilter>();
     }
 
 } initFilters;

--- a/rtbkit/core/router/filters/priority.h
+++ b/rtbkit/core/router/filters/priority.h
@@ -28,6 +28,7 @@ struct Priority
     static constexpr unsigned CreativeLocation     = 0x2100;
     static constexpr unsigned CreativeExchangeName = 0x2200;
     static constexpr unsigned CreativeLanguage     = 0x2300;
+    static constexpr unsigned CreativePMP          = 0x2400;
 
     static constexpr unsigned Segments             = 0x3000;
     static constexpr unsigned HourOfWeek           = 0x3100;

--- a/rtbkit/core/router/filters/testing/creative_filters_test.cc
+++ b/rtbkit/core/router/filters/testing/creative_filters_test.cc
@@ -215,3 +215,92 @@ BOOST_AUTO_TEST_CASE( testSegmentsFilter )
     check(filter, br3, creatives, 0, { {1}, {2}         });
 
 }
+
+
+/******************************************************************************/
+/* PMP FILTER                                                              */
+/******************************************************************************/
+
+BOOST_AUTO_TEST_CASE( testiPMPFilter )
+{
+    CreativePMPFilter filter;
+    CreativeMatrix creatives;
+    auto addDeal = [] (AgentConfig& cfg, const std::string& dealId) {
+        for ( auto& c : cfg.creatives)
+            c.dealId = dealId;
+    };
+  
+    auto addImpr = [] (BidRequest& br,OpenRTB::AdPosition::Vals pos, OpenRTB::PMP& pmp) {
+        AdSpot imp;
+        imp.position.val = pos;
+        imp.pmp.emplace(pmp);
+        br.imp.push_back(imp);
+    };
+
+
+// With DealId DEAL1
+    AgentConfig c0;
+    c0.creatives.push_back(Creative());
+    c0.creatives.push_back(Creative(100, 100));
+    c0.creatives.push_back(Creative(300, 300));
+    addDeal(c0, "DEAL1");
+
+// With DealId DEAL2
+    AgentConfig c1;
+    c1.creatives.push_back(Creative(100, 100));
+    c1.creatives.push_back(Creative(200, 200));
+    addDeal(c1, "DEAL2");
+
+// With No DealId
+    AgentConfig c2;
+    c2.creatives.push_back(Creative());
+    c2.creatives.push_back(Creative(200, 200));
+
+    OpenRTB::Deal d0;
+    d0.id = Datacratic::Id("DEAL1");
+    OpenRTB::Deal d1;
+    d1.id = Datacratic::Id("DEAL2");
+    
+    // No private Auction 
+    OpenRTB::PMP p0;
+    p0.privateAuction = 0;
+    p0.deals.push_back(d0);
+    
+    // Single DealId in PMP
+    OpenRTB::PMP p1;
+    p1.privateAuction = 1;
+    p1.deals.push_back(d0);
+
+    // Both DealId in PMP
+    OpenRTB::PMP p2;
+    p2.privateAuction = 1;
+    p2.deals.push_back(d0);
+    p2.deals.push_back(d1);
+
+
+    BidRequest r0;
+    addImp(r0, OpenRTB::AdPosition::ABOVE, { {100, 100} }); // No pmp
+    addImpr(r0, OpenRTB::AdPosition::ABOVE, p0); // pmp but No privateAuction
+    addImpr(r0, OpenRTB::AdPosition::ABOVE, p1); // Single Deal
+    addImpr(r0, OpenRTB::AdPosition::ABOVE, p2); // Two Deals
+
+    title("PMP-1");
+    addConfig(filter, 0, c0, creatives);
+    addConfig(filter, 1, c1, creatives);
+    addConfig(filter, 2, c2, creatives);
+
+    check(filter, r0, creatives, 0, { {2},    {2}              });
+    check(filter, r0, creatives, 1, { {2},    {2}              });
+    check(filter, r0, creatives, 2, { {0},    {0},      {0}    });
+    check(filter, r0, creatives, 3, { {0, 1}, {0, 1},   {0}    });
+    
+
+    title("PMP-2");
+    removeConfig(filter, 0, c0, creatives);
+
+    check(filter, r0, creatives, 0, { {2}, {2} });
+    check(filter, r0, creatives, 1, { {2}, {2} });
+    check(filter, r0, creatives, 2, { });
+    check(filter, r0, creatives, 3, { {1}, {1} });
+}
+

--- a/rtbkit/core/router/filters/testing/creative_filters_test.cc
+++ b/rtbkit/core/router/filters/testing/creative_filters_test.cc
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE( testiPMPFilter )
             c.dealId = dealId;
     };
   
-    auto addImpr = [] (BidRequest& br,OpenRTB::AdPosition::Vals pos, OpenRTB::PMP& pmp) {
+    auto addPmpImp = [] (BidRequest& br,OpenRTB::AdPosition::Vals pos, OpenRTB::PMP& pmp) {
         AdSpot imp;
         imp.position.val = pos;
         imp.pmp.emplace(pmp);
@@ -280,9 +280,9 @@ BOOST_AUTO_TEST_CASE( testiPMPFilter )
 
     BidRequest r0;
     addImp(r0, OpenRTB::AdPosition::ABOVE, { {100, 100} }); // No pmp
-    addImpr(r0, OpenRTB::AdPosition::ABOVE, p0); // pmp but No privateAuction
-    addImpr(r0, OpenRTB::AdPosition::ABOVE, p1); // Single Deal
-    addImpr(r0, OpenRTB::AdPosition::ABOVE, p2); // Two Deals
+    addPmpImp(r0, OpenRTB::AdPosition::ABOVE, p0); // pmp but No privateAuction
+    addPmpImp(r0, OpenRTB::AdPosition::ABOVE, p1); // Single Deal
+    addPmpImp(r0, OpenRTB::AdPosition::ABOVE, p2); // Two Deals
 
     title("PMP-1");
     addConfig(filter, 0, c0, creatives);


### PR DESCRIPTION
Goal:
To create a static creative filter for PMP Deals or private auction.

Expected Behavior: 
The expected behavior of the PMP Filter is as follows.
 1. If a bid comes with no pmp object, the bidders without DealId will come into play and winner bidder will serve the ad. 
 2. If a bid comes with private_auction mode (pmp.private_auction = 1) and deal(s), the bidders associated with the deal(s) will come into play. 
 3. If a bid comes with open_auction mode (pmp.private_auction = 0) and deal(s), the bidders without Deal Id will come into play.

Pros: 
It can be one of the most effective filters, when we consider about the private auctions.

Cons:
The filter will be invoked and execute its internal logic even if non of the Agent has Deal ID support.
