### PR TITLE
Added DefaultDescription for the fields "dealid", "w" and "h" of OpenRTB Bid Object

### DIFF
--- a/rtbkit/openrtb/openrtb_parsing.cc
+++ b/rtbkit/openrtb/openrtb_parsing.cc
@@ -303,6 +303,9 @@ DefaultDescription()
     addField("crid", &Bid::crid, "Creative ID",
              new StringIdDescription());
     addField("attr", &Bid::attr, "Creative attributes");
+    addField("dealid", &Bid::dealid, "Deal Id for PMP Auction");
+    addField("w", &Bid::w, "width of ad in pixels");
+    addField("h", &Bid::h, "height of ad in pixels");
     addField("ext", &Bid::ext, "Extensions");
 }
 


### PR DESCRIPTION
The Description for the fields "dealid", "w" and "h" of OpenRTB::Bid object were missing.