### PR TITLE
remove inproperly counter check for http client stress test.

### DIFF
--- a/soa/service/testing/http_client_test.cc
+++ b/soa/service/testing/http_client_test.cc
@@ -455,16 +455,6 @@ BOOST_AUTO_TEST_CASE( test_http_client_stress_test )
                 throw;
             }
 
-            int lowerLimit = std::max(0, (numResponses - numParallel));
-            int upperLimit = std::min(maxReqs, (numResponses + numParallel));
-            if (bodyNbr < lowerLimit || bodyNbr > upperLimit) {
-                throw ML::Exception("number of returned server requests "
-                                    " is anomalous: %d is out of range"
-                                    " [%d,*%d,%d]",
-                                    bodyNbr, lowerLimit,
-                                    numResponses, upperLimit);
-            }
-
             if (numResponses == numReqs) {
                 ML::futex_wake(numResponses);
             }


### PR DESCRIPTION
The logic i have removed can cause the test failed if we increase the FD number for HttpClient. The reason is the logic of the callback function is executed in one MessageLoop and the order is not guaranteed. For example, after the response number has been accumulated to 200 the 14th response(the number returned by HttpGet server) just been processed. In this sort of cases, this logic will throw an exception and terminate the test. So basically, the logic check here is not 100% correct, in some situation it is broken.