### PR TITLE
 Configurable campaign id support

### DIFF
--- a/rtbkit/plugins/exchange/bidswitch_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/bidswitch_exchange_connector.cc
@@ -120,6 +120,11 @@ BidSwitchExchangeConnector::init() {
         "adm",
         GENERATE_MACRO_FOR(data.adm)
     ).optional().snippet();
+    
+    configuration_.addField(
+        "cid",
+        GENERATE_MACRO_FOR(data.cid)
+    ).optional().snippet();
 
     configuration_.addField(
         "advertiser_name",
@@ -418,7 +423,11 @@ setSeatBid(Auction const & auction,
     };
 
     // Put in the variable parts
-    b.cid = Id(resp.agent);
+    if(crinfo->cid.notNull()) 
+        b.cid = crinfo->cid;
+    else 
+        b.cid = Id(resp.agent);
+    
     b.id = Id(auction.id, auction.request->imp[0].id);
     b.impid = auction.request->imp[spotNum].id;
     b.price.val = USD_CPM(resp.price.maxPrice);

--- a/rtbkit/plugins/exchange/bidswitch_exchange_connector.h
+++ b/rtbkit/plugins/exchange/bidswitch_exchange_connector.h
@@ -64,6 +64,7 @@ struct BidSwitchExchangeConnector: public OpenRTBExchangeConnector {
     */
     struct CreativeInfo {
         Id adid;                ///< ID for ad to be service if bid wins
+        Id cid;                ///< campaign id
         std::string nurl;       ///< Win notice URL
         std::vector<std::string> adomain;    ///< Advertiser Domain
         std::string adm; ///< Creative markup for banner ads

--- a/rtbkit/plugins/exchange/casale_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/casale_exchange_connector.cc
@@ -65,6 +65,14 @@ void CasaleExchangeConnector::initCreativeConfiguration()
 
             return true;
     }).required();
+    
+    creativeConfig.addField(
+        "cid",
+        [](const Json::Value& value, CreativeInfo& info) {
+            Datacratic::jsonDecode(value, info.cid);
+
+            return true;
+    }).optional();
 }
 
 double
@@ -205,7 +213,10 @@ CasaleExchangeConnector::setSeatBid(
         spotNum
     };
 
-    bid.cid = Id(resp.agent);
+    if(creativeInfo->cid.notNull()) 
+        bid.cid = creativeInfo->cid;
+    else
+        bid.cid = Id(resp.agent);
     bid.crid = Id(resp.creativeId);
     bid.impid = auction.request->imp[spotNum].id;
     bid.id = Id(auction.id, auction.request->imp[0].id);

--- a/rtbkit/plugins/exchange/casale_exchange_connector.h
+++ b/rtbkit/plugins/exchange/casale_exchange_connector.h
@@ -56,6 +56,7 @@ struct CasaleExchangeConnector : public OpenRTBExchangeConnector {
     struct CreativeInfo {
         std::string adm;
         std::vector<std::string> adomain;
+        Id cid;
     };
 
     typedef CreativeConfiguration<CreativeInfo> CasaleCreativeConfiguration;

--- a/rtbkit/plugins/exchange/nexage_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/nexage_exchange_connector.cc
@@ -168,6 +168,14 @@ NexageExchangeConnector::init()
             Datacratic::jsonDecode(value, data.nurl);
             return true;
     }).optional();
+    
+    configuration_.addField(
+        "cid",
+        [](const Json::Value & value, CreativeInfo & data) {
+            Datacratic::jsonDecode(value, data.cid);
+            return true;
+    }).optional();
+
 
 }
 
@@ -259,7 +267,11 @@ setSeatBid(Auction const & auction,
     };
 
     // Put in the variable parts
-    b.cid = Id(resp.agent);
+    // Use default cid, if cid is not configured.
+    if (crinfo->cid.notNull())
+        b.cid = crinfo->cid;
+    else
+        b.cid = Id(resp.agent);
     b.iurl = crinfo->iurl;
     b.impid = auction.request->imp[spotNum].id;
     b.id = Id(auction.id, auction.request->imp[0].id);

--- a/rtbkit/plugins/exchange/nexage_exchange_connector.h
+++ b/rtbkit/plugins/exchange/nexage_exchange_connector.h
@@ -69,6 +69,7 @@ struct NexageExchangeConnector: public OpenRTBExchangeConnector {
     */
     struct CreativeInfo {
         Id crid;                ///< ID Creative Id
+        Id cid;                ///< campaign ID 
         std::string iurl;       ///< Image URL for content checkin
         std::string  nurl;      ///< win notif url (optional)
         std::string  adm;       ///< XHTML markup  (optional)

--- a/rtbkit/plugins/exchange/spotx_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/spotx_exchange_connector.cc
@@ -68,6 +68,13 @@ SpotXExchangeConnector::initCreativeConfiguration()
 
             return true;
     }).required();
+    
+    creativeConfig.addField(
+        "cid",
+        [](const Json::Value& value, CreativeInfo& info) {
+            Datacratic::jsonDecode(value, info.cid);
+            return true;
+    }).optional();
 }
 
 ExchangeConnector::ExchangeCompatibility
@@ -184,7 +191,10 @@ SpotXExchangeConnector::setSeatBid(
         spotNum
     };
 
-    bid.cid = Id(resp.agent);
+    if (creativeInfo->cid.notNull())
+        bid.cid = creativeInfo->cid;
+    else
+        bid.cid = Id(resp.agent);
     bid.crid = Id(resp.creativeId);
     bid.impid = auction.request->imp[spotNum].id;
     bid.id = Id(auction.id, auction.request->imp[0].id);

--- a/rtbkit/plugins/exchange/spotx_exchange_connector.h
+++ b/rtbkit/plugins/exchange/spotx_exchange_connector.h
@@ -52,6 +52,7 @@ struct SpotXExchangeConnector : public OpenRTBExchangeConnector {
     struct CreativeInfo {
         std::string adm;
         std::vector<std::string> adomain;
+        Id cid;
     };
 
     static Logging::Category print;


### PR DESCRIPTION
- Added configurable cid support for bidswitch, casale, nexage and spotx exchanges.
Referance : https://groups.google.com/a/rtbkit.org/forum/#!searchin/discuss/nexage$20/discuss/5IzY9RH6Xhc/Q0a3p4zNn9MJ