### PR TITLE
Mopub EC : check if impression has a banner object before accessing it.

### DIFF
--- a/rtbkit/plugins/exchange/mopub_exchange_connector.h
+++ b/rtbkit/plugins/exchange/mopub_exchange_connector.h
@@ -57,7 +57,6 @@ struct MoPubExchangeConnector: public OpenRTBExchangeConnector {
     */
     struct CampaignInfo {
         Id seat;          ///< ID of the MoPub exchange seat
-        std::string iurl; ///< Image URL for content checking
     };
 
     virtual ExchangeCompatibility
@@ -70,6 +69,7 @@ struct MoPubExchangeConnector: public OpenRTBExchangeConnector {
     struct CreativeInfo {
         std::string adm;                                ///< Ad markup
         std::vector<std::string> adomain;               ///< Advertiser domains
+        std::string iurl;                               ///< Image URL for content checking
         Id crid;                                        ///< Creative ID
         std::set<std::string> cat;                      ///< Creative category Appendix 6.1
         std::set<int>  type;                            ///< Creative type Appendix 6.2

--- a/rtbkit/plugins/exchange/testing/exchange_testing.mk
+++ b/rtbkit/plugins/exchange/testing/exchange_testing.mk
@@ -1,7 +1,7 @@
 # exchange_testing.mk
 
 $(eval $(call test,rubicon_exchange_connector_test,rubicon_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router cairomm-1.0 cairo sigc-2.0,boost))
-$(eval $(call test,mopub_exchange_connector_test,mopub_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router sigc-2.0,boost manual))
+$(eval $(call test,mopub_exchange_connector_test,mopub_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router sigc-2.0,boost))
 $(eval $(call test,smaato_exchange_connector_test,smaato_exchange bid_test_utils openrtb_exchange bidding_agent rtb_router sigc-2.0,boost))
 $(eval $(call test,gumgum_exchange_connector_test,gumgum_exchange bid_test_utils openrtb_bid_request bidding_agent rtb_router agents_bidder,boost))
 $(eval $(call test,bidswitch_exchange_connector_test,bidswitch_exchange bid_test_utils bidding_agent rtb_router agents_bidder,boost))

--- a/rtbkit/plugins/exchange/testing/mopub_bid_request_no_banner.json
+++ b/rtbkit/plugins/exchange/testing/mopub_bid_request_no_banner.json
@@ -1,0 +1,137 @@
+{
+    "app": {
+        "bundle": "com.withbuddies.dice.free",
+        "cat": [
+            "IAB24",
+            "IAB9",
+            "IAB9-30",
+            "games",
+            "social_networking"
+        ],
+        "id": "agltb3B1Yi1pbmNyDAsSA0FwcBjZnfkSDA",
+        "name": "Dice with Buddies Free Android",
+        "publisher": {
+            "id": "agltb3B1Yi1pbmNyEAsSB0FjY291bnQY-afzEgw",
+            "name": "Scopely, Inc."
+        },
+        "ver": "4.4.1"
+    },
+    "at": 2,
+    "badv": [
+        "ads.undertone.com",
+        "benjaminmoore.com",
+        "club1616.com",
+        "dice",
+        "durex",
+        "fab.com",
+        "garmin.com",
+        "gmogame.com",
+        "hbo.com",
+        "jumptap",
+        "makeitrain:vegasstyle.bigfish.com",
+        "marriott.com",
+        "millennial",
+        "mtv.com",
+        "pretiointeractive.com",
+        "scopely.com",
+        "skeeball",
+        "squaremeals.org",
+        "texasagriculture.gov",
+        "tresensa.com",
+        "usaa.com",
+        "withbuddies.com/dice",
+        "www.maginteractive.com"
+    ],
+    "bcat": [
+        "IAB7-28",
+        "IAB7-39",
+        "IAB7-42",
+        "IAB7-44",
+        "IAB8-5",
+        "IAB8-18",
+        "IAB9-7",
+        "IAB9-9",
+        "IAB9-30",
+        "IAB11",
+        "IAB14-1",
+        "IAB14-3",
+        "IAB23",
+        "IAB25",
+        "IAB25-1",
+        "IAB25-2",
+        "IAB25-3",
+        "IAB25-4",
+        "IAB25-5",
+        "IAB25-6",
+        "IAB25-7",
+        "IAB26",
+        "IAB26-1",
+        "IAB3-7"
+    ],
+    "device": {
+        "carrier": "311-480",
+        "connectiontype": 3,
+        "devicetype": 1,
+        "dnt": 0,
+        "dpidmd5": "d234756be489bf6a88cc191485c9521e",
+        "dpidsha1": "5c01efdc654f1aaeacb69dd0431ead692c04c803",
+        "ext": {
+            "idfa": "3a6d402f-b25a-4c19-b051-5579c393f915"
+        },
+        "geo": {
+            "city": "West Des Moines",
+            "country": "USA",
+            "lat": 42.306305,
+            "lon": -95.06543,
+            "metro": "679",
+            "region": "IA",
+            "zip": "50265"
+        },
+        "ip": "70.198.38.243",
+        "js": 1,
+        "make": "samsung",
+        "model": "SCH-I545",
+        "os": "Android",
+        "osv": "5.0.1",
+        "ua": "Mozilla/5.0 (Linux; Android 5.0.1; SCH-I545 Build/LRX22C; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36"
+    },
+    "id": "4e18ed9d-2dab-484e-a198-f0dcf83d1692",
+    "imp": [
+        {
+            "bidfloor": 5.54,
+            "displaymanager": "mopub",
+            "displaymanagerver": "3.3.0",
+            "id": "1",
+            "instl": 1,
+            "tagid": "8eb488b794f24cb3bf9533fcab9ca315",
+            "video": {
+                "battr": [
+                    1,
+                    7,
+                    8,
+                    9,
+                    10,
+                    13,
+                    14
+                ],
+                "h": 320,
+                "linearity": 1,
+                "maxduration": 120,
+                "mimes": [
+                    "video/mp4",
+                    "video/.3gp"
+                ],
+                "minduration": 16,
+                "protocol": 2,
+                "protocols": [
+                    2,
+                    5
+                ],
+                "w": 480
+            }
+        }
+    ],
+    "user": {
+        "keywords": "versionCode:2104410629,applicationId:com.withbuddies.dice.free,version:4.4.1,userId:34640647"
+    }
+}


### PR DESCRIPTION
+ Fixed mopub EC test and removed the manual execution
+ Move iurl from campaign to creative info (this made the test fail)
+ Removed the video object parsing as an extension since the are
  now RTB2.2 compliant
+ Add test for video only requests
+ Add test for openrtb video object parsing