### PR TITLE
added 'relative' WCM

### DIFF
--- a/rtbkit/common/common.mk
+++ b/rtbkit/common/common.mk
@@ -30,5 +30,6 @@ LIBRTB_LINK := \
 $(eval $(call library,rtb,$(LIBRTB_SOURCES),$(LIBRTB_LINK)))
 
 $(eval $(call library,filter_registry,filter.cc,arch utils rtb))
+$(eval $(call library,relative_win_cost_model,relative_win_cost_model.cc,rtb))
 
 $(eval $(call include_sub_make,testing,,common_testing.mk))

--- a/rtbkit/common/relative_win_cost_model.cc
+++ b/rtbkit/common/relative_win_cost_model.cc
@@ -1,0 +1,32 @@
+/*
+ * relative_win_cost_model.cc
+ * added by Nikolay 26 May 2015
+   Copyright (c) 2015.  All rights reserved.
+ */
+#include "rtbkit/common/win_cost_model.h"
+
+namespace RTBKIT {
+
+namespace {
+
+struct RelativeWinCostModel {
+
+    static Amount evalute(WinCostModel const & model,  Bid const & bid, Amount const & price)
+    {
+        Amount priceReturn(price);
+        if (model.data.isMember("win")){
+            priceReturn.value = (bid.price.value * priceReturn.value) / 1000; // rtbkit converts win price to CPM (e.g. $0.5 = 500CPM), so we need put it back to relative value
+        }
+      return priceReturn;
+    }
+};
+
+struct AtInit {
+    AtInit()
+    {
+      PluginInterface<WinCostModel>::registerPlugin("relative", RelativeWinCostModel::evalute);
+    }
+} atInit;
+} // file scope
+
+} // namespace RTBKIT


### PR DESCRIPTION
New "relative" win cost model, useful for some ssp (spotX, brightroll...) which make little encoding into  win  price.
E.g. bid-price = 3CPM, second-price form ssp = 0.5, real win price = 1.5CPM
