### PR TITLE
fix:  regs object missing in bid request

### DIFF
--- a/rtbkit/common/bid_request.cc
+++ b/rtbkit/common/bid_request.cc
@@ -163,6 +163,8 @@ DefaultDescription()
     addField("unparseable", &BidRequest::unparseable, "Unparseable fields are stored here");
     addField("bidCurrency", &BidRequest::bidCurrency, "Currency we're bidding in");
     addField("ext", &BidRequest::ext, "OpenRTB ext object");
+    addField("blockedCategories", &BidRequest::blockedCategories, "OpenRTB bcat object");
+    addField("regs", &BidRequest::regs, "OpenRTB regs object");
 }
 
 } // namespace Datacratic
@@ -965,6 +967,9 @@ toJson() const
     if (!userIds.empty())
         result["userIds"] = userIds.toJson();
 
+    if (regs)
+        toJsonValue(result["regs"], *regs);
+
     return result;
 }
 
@@ -1092,6 +1097,9 @@ createFromJson(const Json::Value & json)
         }
         else if (it.memberName() == "user") {
             fromJsonOptional(*it, result.user, result.unparseable, "user");
+        }
+        else if (it.memberName() == "regs") {
+            fromJsonOptional(*it, result.regs, result.unparseable, "regs");
         }
         else if (it.memberName() == "unparseable")
             result.unparseable = *it;

--- a/rtbkit/plugins/bid_request/openrtb_bid_request_parser.cc
+++ b/rtbkit/plugins/bid_request/openrtb_bid_request_parser.cc
@@ -647,7 +647,8 @@ onBidRequest(OpenRTB::BidRequest & br) {
 
     // Call V1
     OpenRTBBidRequestParser::onBidRequest(br);
-
+    
+    ctx.br->regs.reset(br.regs.release());
     if(ctx.br->regs)
         this->onRegulations(*br.regs);
 }


### PR DESCRIPTION
- regs object of openrtb 2.2 was parsed by openrtbparser but not populated in bidrequest
- blockedCategories was not populated in bid request.