### PR TITLE
Fixed placement of recordhit

### DIFF
--- a/rtbkit/plugins/exchange/smaato_exchange_connector.cc
+++ b/rtbkit/plugins/exchange/smaato_exchange_connector.cc
@@ -246,13 +246,13 @@ ExchangeConnector::ExchangeCompatibility
 	for (const auto& mimeType : spot.banner->mimes) { 
               if (std::find(crinfo->mimeTypes.begin(), crinfo->mimeTypes.end(), mimeType.type)
                       != crinfo->mimeTypes.end()) {
-                  this->recordHit ("blockedMime");
                   return true;
               }
 	}
       }
-
-       return false;
+       
+      this->recordHit ("blockedMime");
+      return false;
   }
 
 void


### PR DESCRIPTION
recordHit("blockedMime") was triggering when the mimetypes matched. I moved this to above the return statement so it is in the correct position.